### PR TITLE
feat: add acad-cuix-builder skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 Thumbs.db
 *.local.json
+**/obj/
+**/bin/

--- a/README.md
+++ b/README.md
@@ -37,7 +37,19 @@ npx skills add autodesk-platform-services/skills --global
 | [`aps-docs-portal`](skills/aps-docs-portal/SKILL.md) | Navigate the APS documentation portal — decode glossary terms, crawl TOC JSON trees, extract content from static HTML pages, and convert CDN URLs to clickable portal links. | `npx skills add autodesk-platform-services/skills --project --skill aps-docs-portal` |
 | [`aps-mcp-server-gen`](skills/aps-mcp-server-gen/SKILL.md) | Scaffold a custom MCP (Model Context Protocol) server that integrates with APS. Supports Node.js/TypeScript, .NET/C#, and Python. | `npx skills add autodesk-platform-services/skills --project --skill aps-mcp-server-gen` |
 | [`acad-dotnet`](skills/acad-dotnet/SKILL.md) | Scaffold and develop AutoCAD 2027 .NET plugins (AutoCAD, Civil 3D, Plant 3D) targeting .NET 10 / x64. Covers csproj patterns, bundle packaging, desktop testing, and Design Automation deployment. | `npx skills add autodesk-platform-services/skills --project --skill acad-dotnet` |
-| [`acad-cuix-builder`](skills/acad-cuix-builder/SKILL.md) | Generate AutoCAD partial CUIX files from prompts. Describe your ribbon panels and LISP/command buttons conversationally — skill builds a ready-to-CUILOAD `.cuix` with embedded BMP icons. | `npx skills add autodesk-platform-services/skills --global --skill acad-cuix-builder` |
+| [`acad-cuix-builder`](skills/acad-cuix-builder/SKILL.md) | Generate AutoCAD partial CUIX files from prompts. Describe your ribbon panels and LISP/command buttons conversationally — skill builds a ready-to-CUILOAD `.cuix` with embedded BMP icons. Requires `CuixBuilder.exe` — see install note below. | `npx skills add autodesk-platform-services/skills --global --skill acad-cuix-builder` |
+
+### acad-cuix-builder — install CuixBuilder.exe
+
+The skill uses [`CuixBuilder.exe`](https://github.com/ADN-DevTech/acad-cuix-builder/releases/latest) — a self-contained Windows CLI that generates the CUIX XML. Install it once with:
+
+```powershell
+irm https://raw.githubusercontent.com/autodesk-platform-services/skills/main/skills/acad-cuix-builder/install.ps1 | iex
+```
+
+This downloads the latest release to `~\.cuixbuilder\CuixBuilder.exe`. No .NET SDK needed.
+
+> **Source:** [ADN-DevTech/acad-cuix-builder](https://github.com/ADN-DevTech/acad-cuix-builder)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ npx skills add autodesk-platform-services/skills --global
 | [`aps-docs-portal`](skills/aps-docs-portal/SKILL.md) | Navigate the APS documentation portal — decode glossary terms, crawl TOC JSON trees, extract content from static HTML pages, and convert CDN URLs to clickable portal links. | `npx skills add autodesk-platform-services/skills --project --skill aps-docs-portal` |
 | [`aps-mcp-server-gen`](skills/aps-mcp-server-gen/SKILL.md) | Scaffold a custom MCP (Model Context Protocol) server that integrates with APS. Supports Node.js/TypeScript, .NET/C#, and Python. | `npx skills add autodesk-platform-services/skills --project --skill aps-mcp-server-gen` |
 | [`acad-dotnet`](skills/acad-dotnet/SKILL.md) | Scaffold and develop AutoCAD 2027 .NET plugins (AutoCAD, Civil 3D, Plant 3D) targeting .NET 10 / x64. Covers csproj patterns, bundle packaging, desktop testing, and Design Automation deployment. | `npx skills add autodesk-platform-services/skills --project --skill acad-dotnet` |
+| [`acad-cuix-builder`](skills/acad-cuix-builder/SKILL.md) | Generate AutoCAD partial CUIX files from prompts. Describe your ribbon panels and LISP/command buttons conversationally — skill builds a ready-to-CUILOAD `.cuix` with embedded BMP icons. | `npx skills add autodesk-platform-services/skills --global --skill acad-cuix-builder` |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,19 @@ One command installs both the skill and [`CuixBuilder.exe`](https://github.com/A
 irm https://raw.githubusercontent.com/autodesk-platform-services/skills/main/skills/acad-cuix-builder/install.ps1 | iex
 ```
 
-Then in Claude Code: `/acad-cuix-builder`
+Then in your agent:
 
-> **Source:** [ADN-DevTech/acad-cuix-builder](https://github.com/ADN-DevTech/acad-cuix-builder)
+```
+/acad-cuix-builder
+
+I need a ribbon tab called "Drafting Tools" with two panels:
+  Panel 1 — Annotation: Quick Leader (QLEADER), Mtext (MTEXT)
+  Panel 2 — View: Zoom Extents (ZOOM E), Regen (REGEN)
+Save to C:\Plugins\DraftingTools.cuix
+```
+
+→ See [README.md](skills/acad-cuix-builder/README.md) for full usage and examples.  
+→ Source: [ADN-DevTech/acad-cuix-builder](https://github.com/ADN-DevTech/acad-cuix-builder)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -39,15 +39,15 @@ npx skills add autodesk-platform-services/skills --global
 | [`acad-dotnet`](skills/acad-dotnet/SKILL.md) | Scaffold and develop AutoCAD 2027 .NET plugins (AutoCAD, Civil 3D, Plant 3D) targeting .NET 10 / x64. Covers csproj patterns, bundle packaging, desktop testing, and Design Automation deployment. | `npx skills add autodesk-platform-services/skills --project --skill acad-dotnet` |
 | [`acad-cuix-builder`](skills/acad-cuix-builder/SKILL.md) | Generate AutoCAD partial CUIX files from prompts. Describe your ribbon panels and LISP/command buttons conversationally — skill builds a ready-to-CUILOAD `.cuix` with embedded BMP icons. Requires `CuixBuilder.exe` — see install note below. | `npx skills add autodesk-platform-services/skills --global --skill acad-cuix-builder` |
 
-### acad-cuix-builder — install CuixBuilder.exe
+### acad-cuix-builder — one-shot install
 
-The skill uses [`CuixBuilder.exe`](https://github.com/ADN-DevTech/acad-cuix-builder/releases/latest) — a self-contained Windows CLI that generates the CUIX XML. Install it once with:
+One command installs both the skill and [`CuixBuilder.exe`](https://github.com/ADN-DevTech/acad-cuix-builder/releases/latest):
 
 ```powershell
 irm https://raw.githubusercontent.com/autodesk-platform-services/skills/main/skills/acad-cuix-builder/install.ps1 | iex
 ```
 
-This downloads the latest release to `~\.cuixbuilder\CuixBuilder.exe`. No .NET SDK needed.
+Then in Claude Code: `/acad-cuix-builder`
 
 > **Source:** [ADN-DevTech/acad-cuix-builder](https://github.com/ADN-DevTech/acad-cuix-builder)
 

--- a/skills/acad-cuix-builder/README.md
+++ b/skills/acad-cuix-builder/README.md
@@ -1,0 +1,72 @@
+# AutoCAD CUIX Builder Skill
+
+**Conversational ribbon customization for AutoCAD — describe your buttons in plain English, get a ready-to-load `.cuix` file.**
+
+Works in GitHub Copilot, Claude Code, Cursor, and any AI agent that can run a terminal.
+
+---
+
+## Install (one command)
+
+```powershell
+irm https://raw.githubusercontent.com/autodesk-platform-services/skills/main/skills/acad-cuix-builder/install.ps1 | iex
+```
+
+Downloads `CuixBuilder.exe` and installs the skill in one shot. No .NET SDK needed.
+
+Then in your agent: `/acad-cuix-builder`
+
+---
+
+## Example prompt
+
+```
+/acad-cuix-builder
+
+I need a ribbon tab called "Drafting Tools" with two panels:
+
+Panel 1 — Annotation:
+  - Quick Leader button (command: QLEADER)
+  - Mtext button (command: MTEXT)
+
+Panel 2 — View:
+  - Zoom Extents button (command: ZOOM E)
+  - Regen button (command: REGEN)
+
+Save to C:\Plugins\DraftingTools.cuix
+```
+
+The skill collects your plugin name, panels, buttons, and commands — then runs `CuixBuilder.exe` to generate the `.cuix`:
+
+```
+Done: C:\Plugins\DraftingTools.cuix
+In AutoCAD: CUILOAD → browse to C:\Plugins\DraftingTools.cuix
+```
+
+---
+
+## What gets generated
+
+- A partial CUIX file with a **ribbon tab**, **panels**, and **buttons**
+- Each button gets a `^C^C`-prefixed macro automatically (bare commands and LISP expressions both handled)
+- Buttons without an image path get **auto-colored 16×16 BMP placeholders** (cycles blue → green → orange → purple → teal → red → amber → cyan)
+
+Load in AutoCAD with `CUILOAD` — the tab appears instantly in the ribbon.
+
+---
+
+## Command formats the skill understands
+
+| You type | Becomes |
+|---|---|
+| `QLEADER` | `^C^CQLEADER` |
+| `zoom e` | `^C^CZOOM E` |
+| `(alert "Hi")` | `^C^C(alert "Hi")` |
+| `^C^CMYCOMMAND` | `^C^CMYCOMMAND` (unchanged) |
+
+---
+
+## Source
+
+- Skill: [autodesk-platform-services/skills](https://github.com/autodesk-platform-services/skills/tree/main/skills/acad-cuix-builder)
+- Generator: [ADN-DevTech/acad-cuix-builder](https://github.com/ADN-DevTech/acad-cuix-builder)

--- a/skills/acad-cuix-builder/README.md
+++ b/skills/acad-cuix-builder/README.md
@@ -12,7 +12,9 @@ Works in GitHub Copilot, Claude Code, Cursor, and any AI agent that can run a te
 irm https://raw.githubusercontent.com/autodesk-platform-services/skills/main/skills/acad-cuix-builder/install.ps1 | iex
 ```
 
-Downloads `CuixBuilder.exe` and installs the skill in one shot. No .NET SDK needed.
+Downloads `CuixBuilder.exe` (~200 KB) and installs the skill in one shot.
+
+> **Requires .NET 10 runtime** — ships with AutoCAD 2027. No separate SDK install needed.
 
 Then in your agent: `/acad-cuix-builder`
 

--- a/skills/acad-cuix-builder/README.md
+++ b/skills/acad-cuix-builder/README.md
@@ -35,14 +35,16 @@ Panel 2 — View:
   - Zoom Extents button (command: ZOOM E)
   - Regen button (command: REGEN)
 
-Save to C:\Plugins\DraftingTools.cuix
+Save to C:\Temp\DraftingTools.cuix
 ```
 
-The skill collects your plugin name, panels, buttons, and commands — then runs `CuixBuilder.exe` to generate the `.cuix`:
+No image paths needed — if omitted, the skill auto-generates colored 16×16 BMP placeholders for each button.
+
+The skill runs `CuixBuilder.exe` and reports:
 
 ```
-Done: C:\Plugins\DraftingTools.cuix
-In AutoCAD: CUILOAD → browse to C:\Plugins\DraftingTools.cuix
+Done: C:\Temp\DraftingTools.cuix
+In AutoCAD: CUILOAD → browse to C:\Temp\DraftingTools.cuix
 ```
 
 ---
@@ -51,7 +53,7 @@ In AutoCAD: CUILOAD → browse to C:\Plugins\DraftingTools.cuix
 
 - A partial CUIX file with a **ribbon tab**, **panels**, and **buttons**
 - Each button gets a `^C^C`-prefixed macro automatically (bare commands and LISP expressions both handled)
-- Buttons without an image path get **auto-colored 16×16 BMP placeholders** (cycles blue → green → orange → purple → teal → red → amber → cyan)
+- Buttons without an image path get **auto-colored 16×16 BMP placeholders** (blue → green → orange → purple → teal → red → amber → cyan)
 
 Load in AutoCAD with `CUILOAD` — the tab appears instantly in the ribbon.
 

--- a/skills/acad-cuix-builder/SKILL.md
+++ b/skills/acad-cuix-builder/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: acad-cuix-builder
+description: "Generate an AutoCAD partial CUIX file from prompts. Collects plugin name, ribbon panels, buttons, and LISP/command macros — then builds a ready-to-CUILOAD .cuix file with properly embedded BMP icons."
+argument-hint: "Describe the plugin (e.g. 'drafting tools with a Quick Leader button and a Zoom Extents button')"
+compatibility: "Windows only. Requires CuixBuilder.exe (see install.ps1) OR .NET SDK 10.0."
+---
+
+# AutoCAD CUIX Builder
+
+Conversational skill that generates a partial AutoCAD CUIX file. No manual XML editing.
+
+Architecture reference: see `references/cuix-architecture.md`.
+
+---
+
+## Step 0 — Verify generator is available
+
+Run in PowerShell:
+
+```powershell
+$exe = "$env:USERPROFILE\.cuixbuilder\CuixBuilder.exe"
+if (Test-Path $exe) { Write-Host "exe found: $exe" }
+elseif (Get-Command dotnet -ErrorAction SilentlyContinue) { dotnet --version }
+else { Write-Host "Neither found — see install.ps1" }
+```
+
+- **exe found** → use `& $exe <config.json>` in Step 5
+- **dotnet SDK** → use `dotnet run --project <src-path> -c Release -- <config.json>` in Step 5
+- **neither** → tell user to run `install.ps1` first (downloads exe, no SDK needed)
+
+---
+
+## Step 1 — Collect plugin identity
+
+Ask:
+- **Plugin display name** — shown as ribbon tab and group label (e.g. `Drafting Tools`)
+- **Internal name** — derive from display name, no spaces (e.g. `DraftingTools`)
+
+---
+
+## Step 2 — Collect panels
+
+Ask:
+- How many ribbon panels?
+- Name of each panel (e.g. `Annotation`, `View`)
+
+---
+
+## Step 3 — Collect buttons (per panel)
+
+For each panel, for each button ask:
+- **Label** — text on the button (e.g. `Quick Leader`)
+- **Command** — one of:
+  - Bare AutoCAD command: `QLEADER` → generator adds `^C^C` automatically
+  - LISP expression: `(alert "hi")` → generator adds `^C^C` automatically
+  - Pre-formatted: `^C^CMYCOMMAND` → used as-is
+- **Image** — path to `.bmp` file, or Enter/`skip` → auto-generates a colored 16×16 placeholder
+- **Tooltip** — optional hover text (defaults to label)
+
+---
+
+## Step 4 — Output path
+
+Ask where to save the `.cuix` file.  
+Default: current directory + `<PluginName>.cuix`
+
+---
+
+## Step 5 — Confirm, build JSON, generate
+
+Show a summary table:
+```
+Plugin : <DisplayName>   Tab : <Tab>   Output : <path>
+
+Panel: <name>
+  [1] <label>  →  <command>   image: <file or "placeholder blue">
+  [2] ...
+```
+
+Confirm with user, then build the JSON config:
+
+```json
+{
+  "pluginName": "NoSpaces",
+  "displayName": "Human Name",
+  "tab": "Tab Label",
+  "outputPath": "C:\\full\\path\\Plugin.cuix",
+  "panels": [
+    {
+      "name": "Panel Name",
+      "buttons": [
+        {
+          "label": "Button Label",
+          "command": "raw input",
+          "imagePath": null,
+          "tooltip": "Optional"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Write config to `$env:TEMP\cuix_<timestamp>.json`, then run:
+
+```powershell
+# With exe (preferred)
+& "$env:USERPROFILE\.cuixbuilder\CuixBuilder.exe" $configPath
+
+# With SDK fallback
+dotnet run --project "<path-to-src>" -c Release -- $configPath
+```
+
+---
+
+## Step 6 — Report result
+
+On success:
+```
+Done: <outputPath>
+In AutoCAD: CUILOAD → browse to <outputPath>
+```
+
+On failure: show stderr and diagnose (common: missing exe, wrong path, invalid JSON).
+
+---
+
+## Command normalization
+
+| User types | Becomes |
+|---|---|
+| `QLEADER` | `^C^CQLEADER` |
+| `zoom e` | `^C^CZOOM E` |
+| `(alert "Hi")` | `^C^C(alert "Hi")` |
+| `^C^CMYCOMMAND` | `^C^CMYCOMMAND` (unchanged) |
+
+---
+
+## Placeholder icon colors (auto-generated when no image provided)
+
+Index cycles 0→7 across all buttons in the CUIX.
+
+| 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |
+|---|---|---|---|---|---|---|---|
+| Blue | Green | Orange | Purple | Teal | Red | Amber | Cyan |

--- a/skills/acad-cuix-builder/install.ps1
+++ b/skills/acad-cuix-builder/install.ps1
@@ -1,4 +1,4 @@
-# install.ps1 — Download CuixBuilder.exe from GitHub Releases
+# install.ps1 — One-shot installer: CuixBuilder.exe + acad-cuix-builder skill
 # Usage: irm https://raw.githubusercontent.com/autodesk-platform-services/skills/main/skills/acad-cuix-builder/install.ps1 | iex
 
 $ErrorActionPreference = "Stop"
@@ -13,7 +13,7 @@ Write-Host "Repository : https://github.com/$repo"
 Write-Host "Install to : $dest"
 Write-Host ""
 
-# Fetch latest release metadata
+# --- Step 1: Download CuixBuilder.exe ---
 $api     = "https://api.github.com/repos/$repo/releases/latest"
 $headers = @{ "User-Agent" = "cuix-builder-installer"; "Accept" = "application/vnd.github+json" }
 $release = Invoke-RestMethod -Uri $api -Headers $headers
@@ -24,16 +24,18 @@ if (-not $asset) {
     exit 1
 }
 
-Write-Host "Downloading $($release.tag_name) / $($asset.name) ($([math]::Round($asset.size/1MB, 1)) MB)..."
+Write-Host "[1/2] Downloading $($release.tag_name) / $($asset.name) ($([math]::Round($asset.size/1MB, 1)) MB)..."
 
 New-Item -ItemType Directory -Force -Path $dest | Out-Null
 Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $exe -UseBasicParsing
 
+Write-Host "      Saved to: $exe"
 Write-Host ""
-Write-Host "Done."
-Write-Host "  Exe : $exe"
+
+# --- Step 2: Install the skill ---
+Write-Host "[2/2] Installing acad-cuix-builder skill..."
+npx --yes skills add autodesk-platform-services/skills --global --skill acad-cuix-builder
+
 Write-Host ""
-Write-Host "Next: install the skill (if not already done)"
-Write-Host "  npx skills add autodesk-platform-services/skills --global --skill acad-cuix-builder"
+Write-Host "All done. In Claude Code, type: /acad-cuix-builder"
 Write-Host ""
-Write-Host "Then in Claude Code: /acad-cuix-builder"

--- a/skills/acad-cuix-builder/install.ps1
+++ b/skills/acad-cuix-builder/install.ps1
@@ -1,5 +1,6 @@
 # install.ps1 — One-shot installer: CuixBuilder.exe + acad-cuix-builder skill
 # Usage: irm https://raw.githubusercontent.com/autodesk-platform-services/skills/main/skills/acad-cuix-builder/install.ps1 | iex
+# Requires: .NET 10 runtime (ships with AutoCAD 2027)
 
 $ErrorActionPreference = "Stop"
 

--- a/skills/acad-cuix-builder/install.ps1
+++ b/skills/acad-cuix-builder/install.ps1
@@ -1,0 +1,39 @@
+# install.ps1 — Download CuixBuilder.exe from GitHub Releases
+# Usage: irm https://raw.githubusercontent.com/autodesk-platform-services/skills/main/skills/acad-cuix-builder/install.ps1 | iex
+
+$ErrorActionPreference = "Stop"
+
+$repo  = "autodesk-platform-services/cuix-builder"
+$dest  = "$env:USERPROFILE\.cuixbuilder"
+$exe   = "$dest\CuixBuilder.exe"
+
+Write-Host ""
+Write-Host "CuixBuilder installer"
+Write-Host "Repository : https://github.com/$repo"
+Write-Host "Install to : $dest"
+Write-Host ""
+
+# Fetch latest release metadata
+$api     = "https://api.github.com/repos/$repo/releases/latest"
+$headers = @{ "User-Agent" = "cuix-builder-installer"; "Accept" = "application/vnd.github+json" }
+$release = Invoke-RestMethod -Uri $api -Headers $headers
+$asset   = $release.assets | Where-Object { $_.name -eq "CuixBuilder.exe" } | Select-Object -First 1
+
+if (-not $asset) {
+    Write-Error "CuixBuilder.exe not found in release $($release.tag_name). Check https://github.com/$repo/releases"
+    exit 1
+}
+
+Write-Host "Downloading $($release.tag_name) / $($asset.name) ($([math]::Round($asset.size/1MB, 1)) MB)..."
+
+New-Item -ItemType Directory -Force -Path $dest | Out-Null
+Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $exe -UseBasicParsing
+
+Write-Host ""
+Write-Host "Done."
+Write-Host "  Exe : $exe"
+Write-Host ""
+Write-Host "Next: install the skill (if not already done)"
+Write-Host "  npx skills add autodesk-platform-services/skills --global --skill acad-cuix-builder"
+Write-Host ""
+Write-Host "Then in Claude Code: /acad-cuix-builder"

--- a/skills/acad-cuix-builder/install.ps1
+++ b/skills/acad-cuix-builder/install.ps1
@@ -3,7 +3,7 @@
 
 $ErrorActionPreference = "Stop"
 
-$repo  = "autodesk-platform-services/cuix-builder"
+$repo  = "ADN-DevTech/acad-cuix-builder"
 $dest  = "$env:USERPROFILE\.cuixbuilder"
 $exe   = "$dest\CuixBuilder.exe"
 

--- a/skills/acad-cuix-builder/install.ps1
+++ b/skills/acad-cuix-builder/install.ps1
@@ -4,9 +4,11 @@
 
 $ErrorActionPreference = "Stop"
 
-$repo  = "ADN-DevTech/acad-cuix-builder"
-$dest  = "$env:USERPROFILE\.cuixbuilder"
-$exe   = "$dest\CuixBuilder.exe"
+$repo      = "ADN-DevTech/acad-cuix-builder"
+$skillsRaw = "https://raw.githubusercontent.com/autodesk-platform-services/skills/main/skills/acad-cuix-builder"
+$dest      = "$env:USERPROFILE\.cuixbuilder"
+$exe       = "$dest\CuixBuilder.exe"
+$skillDest = "$env:USERPROFILE\.claude\skills\acad-cuix-builder"
 
 Write-Host ""
 Write-Host "CuixBuilder installer"
@@ -33,10 +35,26 @@ Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $exe -UseBasicParsin
 Write-Host "      Saved to: $exe"
 Write-Host ""
 
-# --- Step 2: Install the skill ---
+# --- Step 2: Install skill files directly ---
 Write-Host "[2/2] Installing acad-cuix-builder skill..."
-npx --yes skills add autodesk-platform-services/skills --global --skill acad-cuix-builder
+
+$files = @(
+    "SKILL.md",
+    "README.md",
+    "references/cuix-architecture.md"
+)
+
+foreach ($file in $files) {
+    $dir = Split-Path "$skillDest\$file" -Parent
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+    Invoke-WebRequest -Uri "$skillsRaw/$file" -OutFile "$skillDest\$file" -UseBasicParsing
+    Write-Host "      $file"
+}
 
 Write-Host ""
-Write-Host "All done. In Claude Code, type: /acad-cuix-builder"
+Write-Host "All done."
+Write-Host "  Exe   : $exe"
+Write-Host "  Skill : $skillDest"
+Write-Host ""
+Write-Host "In Claude Code, type: /acad-cuix-builder"
 Write-Host ""

--- a/skills/acad-cuix-builder/install.ps1
+++ b/skills/acad-cuix-builder/install.ps1
@@ -1,14 +1,12 @@
-# install.ps1 — One-shot installer: CuixBuilder.exe + acad-cuix-builder skill
+# install.ps1 — Download CuixBuilder.exe from GitHub Releases
 # Usage: irm https://raw.githubusercontent.com/autodesk-platform-services/skills/main/skills/acad-cuix-builder/install.ps1 | iex
 # Requires: .NET 10 runtime (ships with AutoCAD 2027)
 
 $ErrorActionPreference = "Stop"
 
-$repo      = "ADN-DevTech/acad-cuix-builder"
-$skillsRaw = "https://raw.githubusercontent.com/autodesk-platform-services/skills/main/skills/acad-cuix-builder"
-$dest      = "$env:USERPROFILE\.cuixbuilder"
-$exe       = "$dest\CuixBuilder.exe"
-$skillDest = "$env:USERPROFILE\.claude\skills\acad-cuix-builder"
+$repo  = "ADN-DevTech/acad-cuix-builder"
+$dest  = "$env:USERPROFILE\.cuixbuilder"
+$exe   = "$dest\CuixBuilder.exe"
 
 Write-Host ""
 Write-Host "CuixBuilder installer"
@@ -16,7 +14,6 @@ Write-Host "Repository : https://github.com/$repo"
 Write-Host "Install to : $dest"
 Write-Host ""
 
-# --- Step 1: Download CuixBuilder.exe ---
 $api     = "https://api.github.com/repos/$repo/releases/latest"
 $headers = @{ "User-Agent" = "cuix-builder-installer"; "Accept" = "application/vnd.github+json" }
 $release = Invoke-RestMethod -Uri $api -Headers $headers
@@ -27,34 +24,11 @@ if (-not $asset) {
     exit 1
 }
 
-Write-Host "[1/2] Downloading $($release.tag_name) / $($asset.name) ($([math]::Round($asset.size/1MB, 1)) MB)..."
+Write-Host "Downloading $($release.tag_name) / $($asset.name) ($([math]::Round($asset.size/1MB, 1)) MB)..."
 
 New-Item -ItemType Directory -Force -Path $dest | Out-Null
 Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $exe -UseBasicParsing
 
-Write-Host "      Saved to: $exe"
 Write-Host ""
-
-# --- Step 2: Install skill files directly ---
-Write-Host "[2/2] Installing acad-cuix-builder skill..."
-
-$files = @(
-    "SKILL.md",
-    "README.md",
-    "references/cuix-architecture.md"
-)
-
-foreach ($file in $files) {
-    $dir = Split-Path "$skillDest\$file" -Parent
-    New-Item -ItemType Directory -Force -Path $dir | Out-Null
-    Invoke-WebRequest -Uri "$skillsRaw/$file" -OutFile "$skillDest\$file" -UseBasicParsing
-    Write-Host "      $file"
-}
-
-Write-Host ""
-Write-Host "All done."
-Write-Host "  Exe   : $exe"
-Write-Host "  Skill : $skillDest"
-Write-Host ""
-Write-Host "In Claude Code, type: /acad-cuix-builder"
+Write-Host "Done. CuixBuilder.exe ready at: $exe"
 Write-Host ""

--- a/skills/acad-cuix-builder/references/cuix-architecture.md
+++ b/skills/acad-cuix-builder/references/cuix-architecture.md
@@ -1,0 +1,194 @@
+# CUIX File Architecture
+
+## Layer 1 — Container (OPC / ZIP)
+
+CUIX is an **Open Packaging Convention** archive — same container standard as `.docx`, `.xlsx`. Every file inside is a "part". Two OPC metadata files govern the package:
+
+```
+MyPlugin.cuix  (ZIP)
+│
+├── [Content_Types].xml     ← MIME type registry for all extensions in the package
+└── _rels/
+    └── .rels               ← Relationship manifest: who owns what, what type each part is
+```
+
+`_rels/.rels` has two relationship types:
+
+| Type | Target | Purpose |
+|---|---|---|
+| `CUI` | `/*.cui` | AutoCAD loads these as customization parts |
+| `Image` | `/*.bmp` | CUIx Image Manager discovers embedded bitmaps via this |
+
+Without a `Type="Image"` rel, the BMP is a dead file in the ZIP.
+
+---
+
+## Layer 2 — Package Manifest
+
+```
+Menu_Package_Info.xml
+```
+
+Lists every part (CUI files + images) with a modification timestamp. AutoCAD uses this for change detection and incremental reload. Every embedded file needs a `PartData` entry here.
+
+---
+
+## Layer 3 — CUI Parts
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        CUIX Package                             │
+│                                                                 │
+│  ┌──────────────┐   ┌─────────────────────────────────────┐    │
+│  │  Header.cui  │   │           MenuGroup.cui             │    │
+│  │              │   │  ┌─────────────────────────────┐    │    │
+│  │ FileVersion  │   │  │  MenuMacro  UID="MM_0001"   │    │    │
+│  │ PartialMenu  │   │  │  ├── Command: ^C^CMYCMD      │    │    │
+│  │   refs       │   │  │  ├── SmallImage: MyBtn.bmp   │    │    │
+│  │ ToolTip      │   │  │  └── LargeImage: MyBtn.bmp   │    │    │
+│  │   sources    │   │  └─────────────────────────────┘    │    │
+│  └──────────────┘   │  ┌─────────────────────────────┐    │    │
+│                     │  │  MenuMacro  UID="MM_0002"   │    │    │
+│                     │  │  ...                         │    │    │
+│                     │  └─────────────────────────────┘    │    │
+│                     └─────────────────────────────────────┘    │
+│                                    ▲                            │
+│                    All UI parts reference MenuMacro by UID      │
+│                                    │                            │
+│  ┌──────────────────────────────────────────────────────────┐  │
+│  │                    UI Surface Parts                       │  │
+│  │                                                           │  │
+│  │  RibbonRoot.cui          ToolbarRoot.cui                  │  │
+│  │  ├─ RibbonTabSource      ├─ Toolbar                       │  │
+│  │  │  └─ RibbonPanel       │  └─ ToolbarButton              │  │
+│  │  │     └─ RibbonRow         MenuMacroID="MM_0001" ───┐    │  │
+│  │  │        └─ RibbonCmd                               │    │  │
+│  │  │           MenuMacroID="MM_0001" ──────────────────┘    │  │
+│  │  │                                                         │  │
+│  │  PopMenuRoot.cui         QuickAccessToolbarRoot.cui        │  │
+│  │  AcceleratorRoot.cui     WorkspaceRoot.cui                 │  │
+│  │  MouseButtonRoot.cui     DoubleClickRoot.cui               │  │
+│  └──────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ┌──────────────────────────────────────────────────────────┐  │
+│  │                  Legacy / Aux Parts                       │  │
+│  │                                                           │  │
+│  │  ImageMenuRoot.cui       ScreenMenuRoot.cui               │  │
+│  │  TabletMenuRoot.cui      DigitizerButtonRoot.cui          │  │
+│  │  QuickPropertiesRoot.cui RolloverTooltipRoot.cui          │  │
+│  └──────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ┌──────────────────────────────────────────────────────────┐  │
+│  │                  Embedded Images                          │  │
+│  │                                                           │  │
+│  │  MyButton.bmp   (16×16 or 32×32, 24-bit BMP)             │  │
+│  └──────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Layer 4 — The Indirection Chain
+
+UI elements never directly contain command strings or image data. Everything routes through `MenuGroup.cui`:
+
+```
+RibbonCommandButton
+  MenuMacroID="MM_0001"
+        │
+        ▼
+  MenuMacro UID="MM_0001"   (in MenuGroup.cui)
+  ├── Command: ^C^CMYCMD     ← what executes
+  ├── Name: "My Command"     ← tooltip/label source
+  ├── SmallImage: "Btn.bmp"  ← 16×16 icon
+  └── LargeImage: "Btn.bmp"  ← 32×32 icon
+              │
+              ▼
+        _rels/.rels
+        Type="Image" Target="/Btn.bmp"
+              │
+              ▼
+         Btn.bmp   (ZIP entry)
+```
+
+One `MenuMacro` can be referenced by ribbon button + toolbar button + QAT button + accelerator simultaneously. Change the command or image in one place → all surfaces update.
+
+---
+
+## CUI Part Reference Sheet
+
+| File | Root Element | Owns |
+|---|---|---|
+| `Header.cui` | `<CustSection>` | File version, partial CUIX references, tooltip XAML sources |
+| `MenuGroup.cui` | `<MenuGroup>` | **All command definitions** — the central registry |
+| `RibbonRoot.cui` | `<RibbonRoot>` | Tabs → Panels → Rows → Buttons |
+| `ToolbarRoot.cui` | `<ToolbarRoot>` | Classic floating toolbars |
+| `PopMenuRoot.cui` | `<PopMenuRoot>` | Right-click context menus |
+| `AcceleratorRoot.cui` | `<AcceleratorRoot>` | Keyboard shortcuts |
+| `MouseButtonRoot.cui` | `<MouseButtonRoot>` | Mouse button overrides |
+| `DoubleClickRoot.cui` | `<DoubleClickRoot>` | Double-click actions per object type |
+| `QuickAccessToolbarRoot.cui` | `<QuickAccessToolbarRoot>` | QAT buttons |
+| `WorkspaceRoot.cui` | `<WorkspaceRoot>` | Which toolbars/ribbons are visible per workspace |
+| `QuickPropertiesRoot.cui` | `<QuickPropertiesRoot>` | Quick Properties panel config |
+| `RolloverTooltipRoot.cui` | `<RolloverTooltipRoot>` | Rollover tooltip content per object |
+| `ImageMenuRoot.cui` | `<ImageMenuRoot>` | Legacy slide-library image menus |
+| `ScreenMenuRoot.cui` | `<ScreenMenuRoot>` | Legacy screen (cursor) menu |
+| `TabletMenuRoot.cui` | `<TabletMenuRoot>` | Digitizer tablet menu grid |
+| `DigitizerButtonRoot.cui` | `<DigitizerButtonRoot>` | Digitizer puck button assignments |
+
+---
+
+## Image Resolution Chain (custom CUIX only)
+
+```
+SmallImage Name="Btn.bmp"
+        │
+        │  AutoCAD checks _rels/.rels
+        ▼
+<Relationship Type="Image" Target="/Btn.bmp" Id="R...">
+        │
+        │  Resolves to ZIP entry
+        ▼
+/Btn.bmp  (raw BMP bytes in ZIP root)
+        │
+        │  Content type validated against
+        ▼
+<Default Extension="bmp" ContentType="image/bmp">  ([Content_Types].xml)
+```
+
+`acad.cuix` skips this entire chain — its `RCDATA_16_*` names are Win32 resource IDs resolved
+directly from AutoCAD's loaded DLLs at runtime, never touching the ZIP.
+
+---
+
+## Partial vs Main CUIX
+
+| | Main (`acad.cuix`) | Partial (`myplugin.cuix`) |
+|---|---|---|
+| Loaded by | AutoCAD automatically | `CUILOAD` / `PackageContents.xml` |
+| Scope | Full workspace definition | Additive — merges into main |
+| `Header.cui` references | Lists other partial CUIXes | Empty / minimal |
+| Images | Win32 RCDATA resources | Embedded BMP in ZIP with `Type="Image"` rel |
+| `WorkspaceRoot.cui` | Full workspace config | Usually empty stub |
+
+---
+
+## Adding Images — Four Required Steps
+
+| Step | File | Change |
+|---|---|---|
+| 1 | ZIP root | Add `MyButton.bmp` at root (no subfolder) |
+| 2 | `[Content_Types].xml` | `<Default Extension="bmp" ContentType="image/bmp" />` |
+| 3 | `_rels/.rels` | `<Relationship Type="Image" Target="/MyButton.bmp" Id="R{unique16hex}" />` |
+| 4 | `Menu_Package_Info.xml` | `<PartData PartData_Name="/MyButton.bmp" PartData_Modified="..." />` |
+
+Step 3 is the critical one — without `Type="Image"`, the CUIx Image Manager cannot see the file.
+
+---
+
+## Reference Project
+
+`D:\Dev\32520\src\CuixBuilder\` — console app that generates a minimal valid CUIX from scratch
+with one ribbon tab, one panel, one button, and one embedded BMP. No AutoCAD SDK required.
+
+Working real-world reference with embedded BMPs: `D:\Dev\32337\src\One_CAD_Tools\...\OneCadTools100.cuix`


### PR DESCRIPTION
## acad-cuix-builder skill

Conversational skill to generate AutoCAD partial CUIX files from prompts.

### What's included
- SKILL.md — step-by-step agent instructions (collect plugin name, panels, buttons, run CuixBuilder.exe)
- README.md — install guide + example prompt
- eferences/cuix-architecture.md — CUIX XML structure reference
- install.ps1 — downloads CuixBuilder.exe from [ADN-DevTech/acad-cuix-builder](https://github.com/ADN-DevTech/acad-cuix-builder/releases/latest) (~200KB, requires .NET 10)
- Updated root README.md with one-shot install instructions

### Install (after merge)

Run once to get the exe:
`powershell
irm https://raw.githubusercontent.com/autodesk-platform-services/skills/main/skills/acad-cuix-builder/install.ps1 | iex
`

Then install the skill:
`ash
npx skills add autodesk-platform-services/skills --global --skill acad-cuix-builder
`

### Tested ✅
- CuixBuilder.exe v1.0.1 downloads in seconds (~200KB)
- Skill generates valid .cuix loaded via CUILOAD in AutoCAD 2027
- Auto-generates colored BMP icons when no image path provided