### PR TITLE
Add flow-ptr-app skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Skills for Autodesk Platform Services
 
-A collection of reusable AI agent skills for [Autodesk Platform Services](https://aps.autodesk.com). Each skill is a self-contained instruction set that teaches a coding agent how to perform a specific APS-related task.
+A collection of reusable AI agent skills for [Autodesk Platform Services](https://aps.autodesk.com) and Autodesk industry clouds like Flow, Forma and Fusion products. Each skill is a self-contained instruction set that teaches a coding agent how to perform a specific Autodesk API-related development task.
 
 https://github.com/user-attachments/assets/7126310c-4ef6-4b21-9b29-a702dfc0a16d
 
@@ -16,6 +16,8 @@ Clone this repository and copy the skill folder to wherever your AI agent looks 
 git clone https://github.com/autodesk-platform-services/skills.git
 cp -r skills/aps-mcp-server-gen ~/.claude/skills/
 cp -r skills/acad-arx-wizard ~/.claude/skills/
+cp -r skills/flow-ptr-app ~/.claude/skills/
+...
 ```
 
 ### Automated installation
@@ -38,6 +40,7 @@ npx skills add autodesk-platform-services/skills --global
 | [`aps-mcp-server-gen`](skills/aps-mcp-server-gen/SKILL.md) | Scaffold a custom MCP (Model Context Protocol) server that integrates with APS. Supports Node.js/TypeScript, .NET/C#, and Python. | `npx skills add autodesk-platform-services/skills --project --skill aps-mcp-server-gen` |
 | [`acad-dotnet`](skills/acad-dotnet/SKILL.md) | Scaffold and develop AutoCAD 2027 .NET plugins (AutoCAD, Civil 3D, Plant 3D) targeting .NET 10 / x64. Covers csproj patterns, bundle packaging, desktop testing, and Design Automation deployment. | `npx skills add autodesk-platform-services/skills --project --skill acad-dotnet` |
 | [`acad-cuix-builder`](skills/acad-cuix-builder/SKILL.md) | Generate AutoCAD partial CUIX files from prompts. Describe your ribbon panels and LISP/command buttons conversationally — skill builds a ready-to-CUILOAD `.cuix` with embedded BMP icons. Requires `CuixBuilder.exe` — see install note below. | `npx skills add autodesk-platform-services/skills --global --skill acad-cuix-builder` |
+| [`flow-ptr-app`](skills/flow-ptr-app/SKILL.md) | Guide for developing Flow Production Tracking (FPTR) / ShotGrid Toolkit apps following a spec-driven lifecycle — capture intent, write and validate a spec, plan, implement, verify, release, and maintain. | `npx skills add autodesk-platform-services/skills --project --skill flow-ptr-app` |
 
 ### acad-cuix-builder — one-shot install
 

--- a/skills/flow-ptr-app/SKILL.md
+++ b/skills/flow-ptr-app/SKILL.md
@@ -1,0 +1,435 @@
+---
+name: create-fptr-app
+description: "Guide for scaffolding a new Flow Production Tracking (FPTR) / ShotGrid Toolkit (sgtk) app from the official tk-multi-starterapp template — setting up a dev sandbox pipeline configuration, forking the template, wiring info.yml/hooks, and testing before pushing to production config. Triggers on: create a new FPTR app, new Flow Production Tracking app, new Toolkit app, tk-multi-starterapp, sgtk app development, tank install_app, tank switch_app, dev sandbox pipeline configuration, ShotGrid Toolkit app."
+---
+
+# Create a Flow Production Tracking (FPTR) Toolkit App
+
+Scaffolds a new Toolkit (`sgtk`) app for Flow Production Tracking (formerly ShotGrid/Shotgun)
+by forking Autodesk's official starter template, rather than building an app from scratch.
+
+Reference guide: [Developing a Toolkit App](https://help.autodesk.com/view/SGDEV/ENU/?guid=SGD_pg_developer_pg_sgtk_developer_app_html)
+Template repo: https://github.com/shotgunsoftware/tk-multi-starterapp
+
+## Before you start: do you really need a new app?
+
+Toolkit has a customization ladder — cheaper options first:
+
+1. **Project settings** — often what looks like "custom behavior" is just a setting on an
+   existing app (`env/includes/settings/...`).
+2. **App settings** — check the target app's `info.yml` for a setting that already does this.
+3. **Hooks** — the app may expose a hook for exactly the behavior you want to change.
+4. **An existing app, mainstream or niche** — search for one (below) before assuming none exists.
+   Fork/extend it (Step 6's "forking an existing app" note) if it's 90% of what you need.
+5. **A brand-new app** — only once steps 1-4 genuinely don't cover it.
+
+**Before scaffolding, search the shotgunsoftware org by keyword — name, description, and
+README** — the table below is a commonly-used subset, not the full catalog, so absence from it
+isn't proof nothing exists (e.g. "import an EDL and create cuts" matches `tk-multi-importcut`,
+not anything named "edl"):
+```bash
+curl -s "https://api.github.com/search/repositories?q=<keyword>+org:shotgunsoftware+in:name,description,readme" \
+  | grep -o '"full_name": *"[^"]*"'
+```
+(Use this `curl`/api.github.com form, not `gh api`, if `gh` is configured against an internal
+GitHub Enterprise host.) If you get a hit, confirm it's not archived, then go to Step 6's forking
+path instead of Step 3's template clone.
+
+| App | What it does |
+|---|---|
+| Panel | Lightweight FPTR overview inside the DCC (Maya, Nuke, Houdini, ...) — current task, activity stream, notes, tasks, versions, publishes, without leaving the app. |
+| About | Displays the current Toolkit context, config, and installed app/engine versions — debugging/support utility. |
+| Launch App | Shortcuts to start any supported application from the web or Desktop interface. |
+| Snapshot | Capture/restore the state of the current DCC scene as a local backup (not shared/published). |
+| Workfiles | Safely create, open, or version up workfiles tied to a task/asset/shot; can also start from an already-published file. |
+| Publish | Lets artists publish work for downstream use, with pre-publish validation and progress/logging; supports both in-DCC and standalone file publishing. |
+| Loader | Browse and load/reference published files into the current DCC, with a customizable, context-aware tree view. |
+| Breakdown | Tracks assets referenced in a scene and flags when newer published versions are available. |
+
+Flame, Nuke, Hiero, Houdini, and Mari ship their own export/tracking apps too — check those the
+same way before scaffolding new. Editorial/cut-import workflows specifically are covered by
+`tk-multi-importcut` (https://github.com/shotgunsoftware/tk-multi-importcut) — an EDL/AAF import
+app that creates Cuts, CutItems, and Versions and links them to Sequences/Shots.
+
+- Full list of ready-to-use apps: https://help.autodesk.com/view/SGDEV/ENU/?guid=SGD_pc_toolkit_apps_html
+- All app/engine/framework source: https://github.com/shotgunsoftware
+
+## Overview
+
+1. Locate the project's pipeline configuration and figure out how it's set up (centralized vs. distributed).
+2. Find or create a **sandbox/dev configuration** to develop against instead of production (strongly advised, not mandatory).
+3. Clone and rename the `tk-multi-starterapp` template.
+4. Install the app into the target configuration and point Toolkit at your local checkout (`switch_app`).
+5. Adjust `info.yml` (name, description, supported engines, required versions, settings schema).
+6. Decide whether the app needs custom **hooks**.
+7. Implement the app (`app.py`, `python/app/dialog.py`), supporting both UI and no-UI paths.
+8. Test and iterate using Toolkit's "Reload and Restart" menu item.
+9. Tag a release and push the sandbox config changes to the production pipeline configuration.
+
+If planning before executing: only step 1's read-only lookup is safe to run during the plan pass —
+it determines the config type/descriptor, which almost every later step branches on. Run it first,
+then draft the rest of the plan from what it returns rather than trying to plan steps 2-9 upfront.
+
+## Step 1 — Locate the project configuration
+
+Before anything else, find the `PipelineConfiguration` you'll actually be developing against, and
+figure out how it's set up. This determines where files live, whether there's a local `tank`
+command to run, and where the app's code goes in Step 3 — get this wrong and
+`install_app`/`switch_app` will look in the wrong place or fail outright.
+
+Check the project's **Pipeline Configurations** page in Flow Production Tracking, or query it via
+the API:
+
+```python
+sg.find_one(
+    "PipelineConfiguration",
+    [["project", "is", {"type": "Project", "id": PROJECT_ID}], ["code", "is", "Primary"]],
+    ["mac_path", "windows_path", "linux_path", "descriptor"],
+)
+```
+
+**Planning boundary:** this query (and reading the descriptor scheme below) is read-only and safe
+to run during a plan pass — it doesn't touch the filesystem or any repo. Almost everything else in
+this skill branches on what it returns (sandbox strategy, install method, and whether Step 1 itself
+ends in "blocked, escalate" for some descriptor types), so treat this lookup as the plan-phase
+action and draft the rest of the plan *after* it returns, rather than trying to plan the whole
+thing upfront. Everything from here on — cloning, write-access probes, `tank` commands — is the
+execute phase.
+
+- **Populated `mac_path`/`windows_path`/`linux_path`, no `descriptor`** → **centralized (classic)**
+  configuration.
+- **Populated `descriptor`, empty path fields** → **distributed** configuration.
+
+**Centralized (classic):** the whole config lives at one fixed path shared by every machine. Read
+[references/centralized-config.md](references/centralized-config.md) before continuing — it covers
+the access checks you must run before touching that path, plus how sandboxing, cloning, and the
+final release descriptor (Steps 2, 3, and 9) differ for this config type.
+
+**Distributed:** there's no single fixed install location — every machine resolves the `descriptor`
+on demand into its own local bundle cache. Read
+[references/distributed-config.md](references/distributed-config.md) before continuing — read the
+whole file, not just the descriptor-type table: some descriptor types (App Store, FPTR-attachment)
+carry escalation steps that are easy to miss if skipped.
+
+## Step 2 — Find or create a sandbox/dev configuration (strongly advised, not mandatory)
+
+You *can* develop directly against the configuration located in Step 1, even if it's production —
+Toolkit doesn't technically stop you. It's just a bad idea: a half-finished app can break real
+menus/commands for everyone else on the project, and any test data/events you generate land in
+production. Use a sandbox unless you have a specific reason not to.
+
+First check whether a dev sandbox already exists for this project — look for one already
+cloned/flagged for dev use on the Pipeline Configurations page, or ask the user directly. If one
+exists, skip to Step 3 and target it instead of production.
+
+If one doesn't exist yet, create it by following the "Creating a sandbox" section of whichever
+reference file you read in Step 1 —
+[references/centralized-config.md](references/centralized-config.md) or
+[references/distributed-config.md](references/distributed-config.md). Either way, once you have a
+target configuration you also know where the app's own code should be cloned to in Step 3.
+
+## Step 3 — Clone and rename the starter template
+
+Name the app, following the `tk-ENGINE-APPNAME` convention:
+
+- `tk-multi-<appname>` if the app should run in more than one engine (Maya, 3ds Max, Nuke, Desktop, Shell, ...)
+- `tk-<engine>-<appname>` if it's tied to one DCC, e.g. `tk-maya-characterposer`
+
+**Ask where the app's source should be cloned to — don't assume.** The default target and clone
+command depend on config type — follow the "Cloning the app template" section of
+[references/centralized-config.md](references/centralized-config.md) or
+[references/distributed-config.md](references/distributed-config.md) (whichever matches Step 1),
+which also covers when the user might still prefer a separate workspace folder over the config-type
+default.
+
+**Working from GitHub's UI:** fork https://github.com/shotgunsoftware/tk-multi-starterapp (or
+download it as a zip) into your own repo instead, then place/rename it per the reference file above.
+
+The template already ships with:
+
+```
+app.py                 # Application entry point, registers menu commands
+info.yml               # Manifest: metadata, settings schema, frameworks, version requirements
+python/app/__init__.py
+python/app/dialog.py   # Main window logic / callbacks
+python/app/ui/         # Auto-generated from resources/dialog.ui (pyside2-uic / build_resources.yml)
+resources/dialog.ui    # Qt Designer source for the UI
+resources/resources.qrc
+style.qss              # Qt stylesheet
+```
+
+## Step 4 — Install the app into the target configuration
+
+Pick the environment (e.g. `shot_step` for Shots, `asset_step` for Assets, or `project` if the app
+only needs project-level context) and the engine you're targeting (`tk-maya`, `tk-nuke`,
+`tk-desktop`, `tk-shell`, ...). Starting with the `tk-shell` engine in the `project` environment is
+often the fastest loop for early logic-only development (no DCC startup required, and you can run
+it straight from the command line or your IDE if you have a centralized config) — you can wire up
+DCC-specific UI/menus afterwards.
+
+**Fastest path — a `dev` location descriptor directly (no git tag needed yet):** a brand-new app
+has no git tag to `install_app` from anyway, so for early development just hand-edit the
+environment YAML and point the app straight at your local checkout:
+
+```yaml
+tk-multi-myapp:
+  location:
+    type: dev
+    path: /path/to/source_code/tk-multi-myapp
+```
+
+This goes wherever the app is wired into an engine's settings (e.g.
+`env/includes/settings/tk-shell.yml`'s `apps:` block for the environment you picked) — see the
+"Adding an app" reference guide for exactly where. Toolkit loads the code directly from that path,
+so every edit is picked up on the next reload — no reinstall step. This is exactly what we did
+earlier in this skill's own dev session, wiring `tk-multi-eventAiCreated` into `tk-shell.yml` and
+`tk-desktop.yml` this way, with no git repo involved at all yet.
+
+`type: dev` is about the development workflow (it's what turns on the "Reload and Restart" menu
+command), not about *where* the code physically sits — `path:` just points at wherever Step 3 put
+it. So it's still `type: dev` whether that path is `<configuration_folder>/install/apps/<name>` or
+an external workspace folder; the type only changes once the app stops being actively developed
+and gets a real release descriptor (`git`/`app_store`/...) in Step 9.
+
+**Alternative — `install_app` + `switch_app`:** useful once the app already has at least one git
+tag (e.g. it started life as an app-store/git app and you're now developing a new feature for it).
+From a shell, `cd` into the sandbox and use its `tank` command:
+
+```bash
+cd /your/development/sandbox
+./tank install_app shot_step tk-maya user@remotehost:/path_to/tk-multi-mynewapp.git
+```
+
+This installs the latest git tag. Launch the DCC from the sandbox against a Shot/Asset task to
+confirm the app loads. Then switch Toolkit to track your local checkout instead of the git tag, so
+code edits are picked up immediately — this produces the same `type: dev` location entry as the
+fastest-path option above, just generated for you rather than hand-written:
+
+```bash
+./tank switch_app shot_step tk-maya tk-multi-mynewapp /Users/you/dev/tk-multi-mynewapp
+```
+
+Either way, these are the files under the sandbox's config that end up changed — useful to know
+when reviewing the diff before `push_configuration`:
+- `env/includes/app_locations.yml` — where Toolkit finds the app's code (git repo, local path, etc.)
+- `env/includes/settings/<my_custom_app>.yml` — the app's own settings for this project
+- `env/includes/settings/tk-<engine>.yml` — wires the app into an engine + pipeline step
+  (asset/shot/sequence/...); make sure the app's settings file is included at the top of this file
+
+> **Engine version:** when the environment config pins an engine (e.g. `tk-maya`), use the
+> latest available engine version for that environment rather than an old pinned one — you get
+> current bug fixes and it avoids chasing issues in the engine that have already been fixed
+> upstream.
+
+## Step 5 — Adjust `info.yml`
+
+Update the manifest to describe the app and its configuration surface:
+
+```yaml
+display_name: "My New App"
+description: "What this app does."
+
+supported_engines:            # leave empty/omit if engine-agnostic
+requires_shotgun_fields:      # PTR entity fields this app depends on, if any
+requires_core_version: "v0.19.18"
+requires_engine_version:      # minimum engine version needed, if any (leave empty unless required)
+deny_permissions:             # restrict which PTR roles/groups can run this app, if needed
+deny_platform:                # restrict OS platforms, if needed
+help_url:                     # URL opened by the app's "help" button, if any
+
+configuration:
+  save_template:
+    type: template
+    default_value: "maya_asset_work"
+    description: "The template to use when building the path to save the file into"
+    allows_empty: False
+  debug_logging:
+    type: bool
+    default_value: false
+    description: "Controls whether debug logging is enabled for this app."
+
+frameworks:
+  - {"name": "tk-framework-shotgunutils", "version": "v2.x.x"}
+  - {"name": "tk-framework-qtwidgets", "version": "v1.x.x", "minimum_version": "v1.5.0"}
+```
+
+`entity_types` is another common setting (which PTR entity types the app applies to — Shots,
+Assets, Versions, ...) and `templates` lets a setting reference a filesystem template instead of
+a literal value/path.
+
+Read settings in code with `self.get_setting("save_template")` (inside `Application`) or
+`app.get_setting(...)` from the dialog module.
+
+Manifest reference: https://developers.shotgridsoftware.com/tk-core/platform.html#manifest-file
+
+## Step 6 — Decide on hooks
+
+Hooks let studios override specific pieces of app behavior per-project without touching the app's
+code — extract a piece of logic that's likely to need per-studio customization (path logic,
+naming, validation rules) into its own hook. Only add one when that's actually likely; most simple
+apps need zero custom hooks.
+
+Declare each hook in `info.yml`'s `configuration` block, and ship the default implementation as its
+own `.py` file (with a `Hook` class) under a `hooks/` folder at the app's code root:
+
+```yaml
+configuration:
+  my_custom_hook:
+    type: hook
+    default_value: "{self}/my_custom_hook.py"
+    description: "Hook to customize X behavior."
+```
+
+**Studios override it** by copying the default hook file into the project config's `hooks/` folder
+(e.g. `my_project_config/config/hooks/my_custom_hook.py`), editing it there, then repointing the
+environment YAML setting at the copy:
+
+```yaml
+hook_before_app_launch: default              # built-in hook
+hook_before_app_launch: before_app_launch    # <- studio's custom copy
+```
+
+Common generic hook names you'll see across apps (useful naming inspiration for your own):
+`hook_before_app_launch`, `hook_app_launch`, `pick_environment`, `hook_before_register_command`,
+`hook_ui_config`, `actions_hook`, `post_load`.
+
+**Alternative to building new — forking an existing app:** if an existing app already covers most
+of what you need and hooks/settings genuinely aren't enough, fork it via git instead of starting
+from the starter template. Convention: place the clone under `config/install/app_store` in the
+config, and point `app_locations.yml` at it:
+
+```yaml
+my_custom_app:
+  location:
+    type: git
+    path: git@github.com:yourstudio/tk-multi-mycustomapp.git
+    version: v1.0.0
+```
+
+When forking, use extended version numbers (`vBASE.LOCAL`, e.g. `v0.2.12.1`) to indicate "based on
+upstream v0.2.12, plus our local patch 1" — this keeps a clear trail back to the original version
+and makes it obvious the tag isn't an upstream release.
+
+More on descriptors: https://developers.shotgridsoftware.com/tk-core/descriptor.html
+
+## Step 7 — Implement the app
+
+- `app.py`: `Application` subclass, registers menu command(s) via `self.engine.register_command(...)`.
+- `python/app/dialog.py`: dialog construction and callbacks.
+- Support **both** UI and no-UI execution paths, since not every engine/context has Qt available:
+  - **With UI**: full Qt window via `self.engine.show_dialog(...)` (PySide2/PySide6 or PyQt).
+  - **Without UI**: a console-only code path (check `self.engine.has_ui`) so the app still works
+    headlessly, e.g. under `tk-shell` or a batch/farm context.
+  - Qt bindings (PySide/PyQt) must be available in whichever Python environment runs the DCP/engine
+    — install PySide2/PySide6 (or PyQt) into that environment if it's missing.
+- As soon as the config has one or more `dev`-descriptor apps in it, Toolkit adds a **Reload and
+  Restart** entry to the PTR menu — use it to pick up code and config changes without restarting
+  the host application. It reloads the config and code and restarts the engine, but any app UI
+  already open on screen does **not** auto-update — close and re-launch it from the menu after
+  reloading to see your changes.
+- App logic will mainly talk to PTR through the **Python API** (`shotgun_api3`, already available
+  via `sgtk`/the engine). It may also need the **REST API** for cases outside a Python/DCC context
+  (e.g. external services, non-Python integrations): https://developers.shotgridsoftware.com/rest-api/
+
+### If the app is a web menu action (`tk-shotgun` engine)
+
+Apps launched from a right-click menu in the FPTR **web** UI (not from inside a DCC) run under the
+`tk-shotgun` engine, which behaves differently from DCC engines like `tk-maya`:
+
+1. Clicking the menu action in the browser sends a request to FPTR Desktop.
+2. Desktop spawns a separate local Python process and bootstraps the `tk-shotgun` engine in it.
+3. Your app code runs in that process — same idea as `python script.py` from the command line,
+   but with the Toolkit framework loaded.
+4. If UI is needed, a Qt app starts there (same with-UI/without-UI detection as above).
+5. All output is captured and sent back to the web interface **only after the process
+   completes** — it is not streamed live.
+
+Implications: this requires FPTR Desktop to be installed and running, plus network connectivity
+for the API calls. Logging goes to the standard Toolkit log files, not the browser console — set
+`debug_logging: true` (see Step 5) while iterating. Don't confuse `tk-shotgun` with `tk-desktop`
+(the engine that runs *inside* the Desktop launcher itself) — they're different engines.
+
+### Triggering custom events
+
+If other systems (the studio's Event Framework daemon, webhooks) should react to something your
+app does, create an `EventLogEntry` yourself via the Python API, e.g.
+`sg.create("EventLogEntry", data)`, using the same naming convention FPTR uses internally:
+`ApplicationName_EntityType_Action` (e.g. `tkMultiEventApp_event_new`).
+
+### Python API best practices
+
+Before writing any non-trivial `sg.find`/`sg.create` calls, read
+[references/python-api-best-practices.md](references/python-api-best-practices.md) — performance,
+API-key/script hygiene, and design guidance that's cheap to follow now and expensive to retrofit
+later. Skip only for trivial, one-off calls.
+
+## Step 8 — Test
+
+- Iterate using Reload and Restart as above.
+- Ask whether to verify headless in `tk-shell` first before testing in the final DCC/engine, or go
+  straight to the final target — `tk-shell` first gives a faster logic-only loop (no DCC startup)
+  and catches non-UI bugs early, but ultimately the dialog/UI still needs to be confirmed working
+  in the real target engine (`tk-desktop` or the DCC itself) before calling it tested.
+- To bring in another tester without giving them production access, add them to the
+  **User Restrictions** field on the sandbox's `PipelineConfiguration` entity in PTR, and make sure
+  they have read access to your app's repo/checkout.
+- The Python API is useful for writing quick test scripts or exercising app logic against real
+  PTR data outside the DCC:
+  - https://developers.shotgridsoftware.com/python-api/
+  - https://help.autodesk.com/view/SGDEV/ENU/?guid=SGD_py_python_api_overview_html
+
+## Step 9 — Release and push to production
+
+An app must be versioned to be installed via a git/App Store/GitHub descriptor at all — Toolkit
+resolves `version:` against git tags, so every release needs one. Use semantic versioning
+(`vMAJOR.MINOR.PATCH`, e.g. start at `v0.1.0` during early development, `v1.0.0` for the first
+production-ready release) and bump it for every change you want the config to be able to pin to.
+
+Tag a version in git (e.g. `v1.0.0`), then switch the sandbox back from dev mode to the tagged
+git descriptor:
+
+```bash
+./tank switch_app shot_step tk-maya tk-multi-mynewapp user@remotehost:/path_to/tk-multi-mynewapp.git
+```
+
+Toolkit will pick up the highest-numbered tag. Finally, push the sandbox's config changes to the
+project's primary production configuration:
+
+```bash
+./tank push_configuration
+```
+
+Other descriptor types are available for the final `location` entry besides a git tag — App Store,
+GitHub releases, or a Shotgun-uploaded attachment — pick whichever matches how the studio
+distributes Toolkit apps.
+
+Descriptor choice for this final release step also differs by config type — see the "Release
+descriptor" note in whichever reference file you read in Step 1
+([references/centralized-config.md](references/centralized-config.md) /
+[references/distributed-config.md](references/distributed-config.md)).
+
+**Later, when you ship a new version:** bump the version manually in `app_locations.yml` (and
+`core_api.yml` if it's a core update), or use the Desktop app's Project menu → "Check for
+configs/core updates" to upgrade automatically, or use `tank` from the project's config, or the
+update API — whichever fits the studio's workflow.
+
+## Reference apps to study
+
+Before designing your own app's architecture, read
+[references/reference-apps.md](references/reference-apps.md) — real Autodesk-maintained apps,
+each demonstrating one distinct, reusable pattern (publish pipelines, hook-per-concern slicing,
+minimal single-hook apps, web menu actions).
+
+## After this skill
+
+Once the app is scaffolded, developed, and tested in the sandbox, come back for help wiring the
+final descriptor and reviewing the environment YAML diff before it's pushed to the production
+pipeline configuration.
+
+## Documentation starting points
+
+- **User documentation** — getting-started guides and know-how articles by production role:
+  https://help.autodesk.com/view/SGSUB/ENU/
+- **Developer documentation** — technical guides for pipeline leads/devs: Toolkit, tools,
+  configurations, APIs, integrations, troubleshooting:
+  https://help.autodesk.com/view/SGDEV/ENU/

--- a/skills/flow-ptr-app/SKILL.md
+++ b/skills/flow-ptr-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-fptr-app
-description: "Guide for scaffolding a new Flow Production Tracking (FPTR) / ShotGrid Toolkit (sgtk) app from the official tk-multi-starterapp template — setting up a dev sandbox pipeline configuration, forking the template, wiring info.yml/hooks, and testing before pushing to production config. Triggers on: create a new FPTR app, new Flow Production Tracking app, new Toolkit app, tk-multi-starterapp, sgtk app development, tank install_app, tank switch_app, dev sandbox pipeline configuration, ShotGrid Toolkit app."
+description: "Guide for developing a new Flow Production Tracking (FPTR) / ShotGrid Toolkit (sgtk) app following a Spec-driven approach. Triggers on: create a new FPTR app, new Flow Production Tracking app, new Toolkit app, tk-multi-starterapp, sgtk app development, tank install_app, tank switch_app, dev sandbox pipeline configuration, ShotGrid Toolkit app."
 ---
 
 # Create a Flow Production Tracking (FPTR) Toolkit App
@@ -8,10 +8,81 @@ description: "Guide for scaffolding a new Flow Production Tracking (FPTR) / Shot
 Scaffolds a new Toolkit (`sgtk`) app for Flow Production Tracking (formerly ShotGrid/Shotgun)
 by forking Autodesk's official starter template, rather than building an app from scratch.
 
+This skill guides developers and pipeline engineers through building an FPTR app, following a
+**spec-driven** way — capture intent, check for reuse, write and validate a spec, plan, then
+implement, verify, release, and maintain against that spec. Tell the user which phase (below)
+you're starting before acting in it, so they can track progress and step in between phases.
+
 Reference guide: [Developing a Toolkit App](https://help.autodesk.com/view/SGDEV/ENU/?guid=SGD_pg_developer_pg_sgtk_developer_app_html)
 Template repo: https://github.com/shotgunsoftware/tk-multi-starterapp
 
-## Before you start: do you really need a new app?
+## Overview
+
+The `## Step N` sections below (Step 0 through Step 9) hold the mechanical how-to for parts of
+Phases 1, 3–6, and 8. Phases 2, 7, and 9 have no dedicated section below — they're about the spec
+and process rather than a tool/config action, so they're covered inline above.
+
+- **Phase 1 — Requirements/Intent capture**
+   - Step 1.1 — Ask for the business need, and capture it in a short spec (one paragraph or a few
+     bullet points) — what the app should do, on which context and environment it will run,
+     whether it needs a UI, whether it needs toolkit hooks, constraints and acceptance criteria.
+   - Step 1.2 — Find if an existing app / project setting / hook cover fully or partially the
+     requirements, and confirm with the user whether later we will fork/extend from that tool or
+     scaffold a new app from the starter template.
+- **Phase 2 — Specification** — before cloning anything, write down what the app does:
+   - Step 2.1 — Clarify the goal, the app name, dependencies on Flow PTR frameworks/engines, the
+     environment the tool runs in (e.g. Sequence/Shot/Episode-specific), the entities involved, the
+     settings schema, which hooks the tool may need to expose and why, whether it needs a UI, and
+     its acceptance criteria.
+   - Step 2.2 — Validate the spec before planning: check it for internal contradictions, missing
+     edge cases (no-UI/headless path, permissions, multi-engine support), and security/data-privacy
+     concerns (e.g. what PTR fields/entities the app reads or writes). Flag gaps to the user instead
+     of assuming an answer; only move to Phase 3 once the spec is complete and consistent.
+- **Phase 3 — Plan/Design**
+   - Step 3.1 — Locate the project's pipeline configuration and figure out how it's set up
+     (centralized vs. distributed).
+   - Step 3.2 — Find or create a sandbox or a dev configuration if it doesn't exist.
+   - Step 3.3 — Clarify where the app's source code should live, and how it will be installed into
+     the target configuration (dev path vs. install_app + switch_app).
+   - Step 3.4 — Break the spec into a technical plan: architecture decisions, file/module
+     breakdown, sequencing of work, identification of risks or open questions. Where practical,
+     decide to keep core logic separate from UI code (e.g. `app.py`/a logic module stays
+     UI-agnostic, with `dialog.py` calling into it) — this is what lets Phase 6 exercise the tool
+     as a headless command in `tk-shell` before wiring up the dialog.
+   - Step 3.5 — Split the plan into discrete, independently verifiable tasks/tickets, each with
+     clear inputs/outputs and acceptance criteria, so that the work can be parallelized and
+     tracked.
+- **Phase 4 — Scaffold**
+   - Step 4.1 — Clone the reference tool — `tk-multi-starterapp` by default, or whichever existing
+     app Phase 1 found as a better fit.
+- **Phase 5 — Implement against spec**
+   - Step 5.1 — Fill in `info.yml` and implement code with main logic starting in `app.py` and UI
+     starting in `python/app/dialog.py`. Declare and implement hooks if applicable.
+- **Phase 6 — Verify against spec**
+   - Step 6.1 — Test and iterate using Toolkit's "Reload and Restart" menu item, checked against
+     acceptance criteria, not just "does it run". If possible and it has a dependency on UI, test
+     first in `tk-shell` or a batch context, then in tk-desktop and then in the target DCC engine,
+     if applicable. If app is a Menu Action Item, test it in the FPTR Desktop and then in the web
+     UI.
+- **Phase 7 — Change management**
+   - Step 7.1 — Commit in git, pushing changes only to the sandbox configuration, not
+     production.
+   - Step 7.2 — Future feature changes update the spec first (Phase 2, re-validating it per Step
+     2.2), then cascade forward through Phases 3-6 — the spec stays the source of truth, not the
+     code.
+- **Phase 8 — Release to production**
+   - Step 8.1 — Once ready for release, warn the user about the implications of bringing to
+     production the new changes. Analyse possible side effects or interruptions to workflow.
+   - Step 8.2 — Tag a release and push the sandbox config changes to the production pipeline
+     configuration.
+- **Phase 9 — Maintenance**
+   - Step 9.1 — Treat post-release bug reports or new asks as spec changes, not code patches: update
+     the spec first (back to Phase 2), validate it again, then re-enter Phase 3 and cascade forward
+     through Phases 4-8 — the spec stays the source of truth for the life of the app, not just
+     during initial development.
+
+
+## Find existing apps
 
 Toolkit has a customization ladder — cheaper options first:
 
@@ -20,10 +91,10 @@ Toolkit has a customization ladder — cheaper options first:
 2. **App settings** — check the target app's `info.yml` for a setting that already does this.
 3. **Hooks** — the app may expose a hook for exactly the behavior you want to change.
 4. **An existing app, mainstream or niche** — search for one (below) before assuming none exists.
-   Fork/extend it (Step 6's "forking an existing app" note) if it's 90% of what you need.
-5. **A brand-new app** — only once steps 1-4 genuinely don't cover it.
+   Fork/extend if it's close to what you need.
+5. **A brand-new app** — when nothing found that can be reused.
 
-**Before scaffolding, search the shotgunsoftware org by keyword — name, description, and
+Search in the shotgunsoftware org by keyword — name, description, and
 README** — the table below is a commonly-used subset, not the full catalog, so absence from it
 isn't proof nothing exists (e.g. "import an EDL and create cuts" matches `tk-multi-importcut`,
 not anything named "edl"):
@@ -53,22 +124,6 @@ app that creates Cuts, CutItems, and Versions and links them to Sequences/Shots.
 
 - Full list of ready-to-use apps: https://help.autodesk.com/view/SGDEV/ENU/?guid=SGD_pc_toolkit_apps_html
 - All app/engine/framework source: https://github.com/shotgunsoftware
-
-## Overview
-
-1. Locate the project's pipeline configuration and figure out how it's set up (centralized vs. distributed).
-2. Find or create a **sandbox/dev configuration** to develop against instead of production (strongly advised, not mandatory).
-3. Clone and rename the `tk-multi-starterapp` template.
-4. Install the app into the target configuration and point Toolkit at your local checkout (`switch_app`).
-5. Adjust `info.yml` (name, description, supported engines, required versions, settings schema).
-6. Decide whether the app needs custom **hooks**.
-7. Implement the app (`app.py`, `python/app/dialog.py`), supporting both UI and no-UI paths.
-8. Test and iterate using Toolkit's "Reload and Restart" menu item.
-9. Tag a release and push the sandbox config changes to the production pipeline configuration.
-
-If planning before executing: only step 1's read-only lookup is safe to run during the plan pass —
-it determines the config type/descriptor, which almost every later step branches on. Run it first,
-then draft the rest of the plan from what it returns rather than trying to plan steps 2-9 upfront.
 
 ## Step 1 — Locate the project configuration
 

--- a/skills/flow-ptr-app/SKILL.md
+++ b/skills/flow-ptr-app/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: create-fptr-app
+name: flow-ptr-app
 description: "Guide for developing a new Flow Production Tracking (FPTR) / ShotGrid Toolkit (sgtk) app following a Spec-driven approach. Triggers on: create a new FPTR app, new Flow Production Tracking app, new Toolkit app, tk-multi-starterapp, sgtk app development, tank install_app, tank switch_app, dev sandbox pipeline configuration, ShotGrid Toolkit app."
 ---
 

--- a/skills/flow-ptr-app/SKILL.md
+++ b/skills/flow-ptr-app/SKILL.md
@@ -24,8 +24,9 @@ action, so they're covered inline above.
      bullet points) — what the app should do, on which context and environment it will run,
      whether it needs a UI, whether it needs toolkit hooks, constraints and acceptance criteria.
    - Step 1.2 — Find if an existing app / project setting / hook cover fully or partially the
-     requirements, and confirm with the user whether later we will fork/extend from that tool or
-     scaffold a new app from the starter template.
+     requirements (see [references/existing-functionality.md](references/existing-functionality.md)
+     for the reuse ladder and search steps), and confirm with the user whether later we will
+     fork/extend from that tool or scaffold a new app from the starter template.
 - **Phase 2 — Specification** — before cloning anything, write down what the app does:
    - Step 2.1 — Clarify the goal, the app name, dependencies on Flow PTR frameworks/engines, the
      environment the tool runs in (e.g. Sequence/Shot/Episode-specific), the entities involved, the
@@ -83,35 +84,11 @@ action, so they're covered inline above.
 
 ## Find existing functionality or apps
 
-Toolkit has a customization ladder — cheaper options first:
-
-1. **Project settings** — often what looks like "custom behavior" is just a setting on an
-   existing app (`env/includes/settings/...`).
-2. **App settings** — check the target app's `info.yml` for a setting that already does this.
-3. **Hooks** — the app may already expose a hook for exactly the behavior you want to change.
-4. **An existing app, mainstream or niche** — search for one (below) before assuming none exists.
-   Fork/extend if it's close to what you need.
-5. **A brand-new app** — only once none of the above can be reused.
-
-Best practice is to search the shotgunsoftware org by keyword — name, description, and README —
-before assuming nothing exists:
-```bash
-curl -s "https://api.github.com/search/repositories?q=<keyword>+org:shotgunsoftware+in:name,description,readme" \
-  | grep -o '"full_name": *"[^"]*"'
-```
-(Use this `curl`/api.github.com form, not `gh api`, if `gh` is configured against an internal
-GitHub Enterprise host.) 
-
-Flame, Nuke, Hiero, Houdini, and Mari ship their own export/tracking apps too — check those the
-same way before scaffolding new.
-
-- A list of ready-to-use apps: https://help.autodesk.com/view/SGDEV/ENU/?guid=SGD_pc_toolkit_apps_html
-- All app/engine/framework source: https://github.com/shotgunsoftware
-
-Before designing your own app's architecture, read
-[references/reference-apps.md](references/reference-apps.md) — real Autodesk-maintained apps,
-each demonstrating one distinct, reusable pattern (publish pipelines, hook-per-concern slicing,
-minimal single-hook apps, web menu actions).
+Toolkit has a customization ladder — cheaper options first: project settings, app settings, hooks,
+an existing app (fork/extend it), and only then a brand-new app. Read
+[references/existing-functionality.md](references/existing-functionality.md) before scaffolding
+anything — it covers where/how to search for existing apps and settings, real apps to study for
+architecture patterns, and how to fork one if you go that route.
 
 ## Locating a project configuration
 
@@ -156,7 +133,7 @@ carry escalation steps that are easy to miss if skipped.
 
 ## Find or create a sandbox/dev configuration (strongly advised, not mandatory)
 
-You *can* develop directly against the configuration you located above, even if it's production —
+You *can* develop directly against the project's production configuration instead of a sandbox —
 Toolkit doesn't technically stop you. It's just a bad idea: a half-finished app can break real
 menus/commands for everyone else on the project, and any test data/events you generate land in
 production. Best practice is to use a sandbox unless you have a specific reason not to.
@@ -222,18 +199,16 @@ tk-multi-myapp:
 ```
 
 This goes wherever the app is wired into an engine's settings (e.g.
-`env/includes/settings/tk-shell.yml`'s `apps:` block for the environment you picked) — see the
-"Adding an app" reference guide for exactly where. Toolkit loads the code directly from that path,
-so every edit is picked up on the next reload — no reinstall step. This is exactly what we did
-earlier in this skill's own dev session, wiring `tk-multi-eventAiCreated` into `tk-shell.yml` and
-`tk-desktop.yml` this way, with no git repo involved at all yet.
+`env/includes/settings/tk-shell.yml`'s `apps:` block for the environment you picked). Toolkit loads
+the code directly from that path, so every edit is picked up on the next reload — no reinstall
+step, and no git repo is needed yet.
 
 `type: dev` is about the development workflow (it's what turns on the "Reload and Restart" menu
 command), not about *where* the code physically sits — `path:` just points at wherever the app's
 source was cloned to. So it's still `type: dev` whether that path is
 `<configuration_folder>/install/apps/<name>` or an external workspace folder; the type only changes
 once the app stops being actively developed and gets a real release descriptor (`git`/`app_store`/
-...) — see "Release and push to production" below.
+...) — see "Release and push to production".
 
 **Alternative — `install_app` + `switch_app`:** useful once the app already has at least one git
 tag (e.g. it started life as an app-store/git app and you're now developing a new feature for it).
@@ -337,25 +312,6 @@ Common generic hook names you'll see across apps (useful naming inspiration for 
 `hook_before_app_launch`, `hook_app_launch`, `pick_environment`, `hook_before_register_command`,
 `hook_ui_config`, `actions_hook`, `post_load`.
 
-**Alternative to building new — forking an existing app:** if an existing app already covers most
-of what you need and hooks/settings genuinely aren't enough, fork it via git instead of starting
-from the starter template. Convention: place the clone under `config/install/app_store` in the
-config, and point `app_locations.yml` at it:
-
-```yaml
-my_custom_app:
-  location:
-    type: git
-    path: git@github.com:yourstudio/tk-multi-mycustomapp.git
-    version: v1.0.0
-```
-
-When forking, best practice is to use extended version numbers (`vBASE.LOCAL`, e.g. `v0.2.12.1`) to
-indicate "based on upstream v0.2.12, plus our local patch 1" — this keeps a clear trail back to the
-original version and makes it obvious the tag isn't an upstream release.
-
-More on descriptors: https://developers.shotgridsoftware.com/tk-core/descriptor.html
-
 ## Implement a Flow PTR app
 
 - `app.py`: `Application` subclass, registers menu command(s) via `self.engine.register_command(...)`.
@@ -390,7 +346,7 @@ Apps launched from a right-click menu in the FPTR **web** UI (not from inside a 
 
 Implications: this requires FPTR Desktop to be installed and running, plus network connectivity
 for the API calls. Logging goes to the standard Toolkit log files, not the browser console — set
-`debug_logging: true` (see "Adjust the app descriptor `info.yml`" above) while iterating. Don't
+`debug_logging: true` (see "Adjust the app descriptor `info.yml`") while iterating. Don't
 confuse `tk-shotgun` with `tk-desktop` (the engine that runs *inside* the Desktop launcher itself)
 — they're different engines.
 
@@ -410,7 +366,9 @@ later. Skip only for trivial, one-off calls.
 
 ## Test an app
 
-- Iterate using Reload and Restart as above.
+- Iterate using Toolkit's **Reload and Restart** menu item to pick up code and config changes
+  without restarting the host application (see "Implement a Flow PTR app" for what enables it and
+  its limits).
 - Ask whether to verify headless in `tk-shell` first before testing in the final DCC/engine, or go
   straight to the final target — `tk-shell` first gives a faster logic-only loop (no DCC startup)
   and catches non-UI bugs early, but ultimately the dialog/UI still needs to be confirmed working

--- a/skills/flow-ptr-app/SKILL.md
+++ b/skills/flow-ptr-app/SKILL.md
@@ -93,6 +93,30 @@ rather than a tool/config action.
      through Phases 4-8 — the spec stays the source of truth for the life of the app, not just
      during initial development.
 
+## Reference guides — skip the phases
+
+The phases above are one way to work through building an app — spec-driven, with an explicit
+plan/verify loop. If you're following a different process instead (your own tickets, a different
+planning method, or you're just experienced enough with Toolkit not to need the scaffolding), use
+this table to jump straight to the how-to you need. Each guide is self-contained and doesn't assume
+you've read the phases above.
+
+| Guide | What it covers |
+|---|---|
+| [references/existing-functionality.md](references/existing-functionality.md) | Toolkit's customization ladder, GitHub org search for reuse, and reference apps to study for architecture patterns |
+| [references/locating-config.md](references/locating-config.md) | Finding the project's `PipelineConfiguration` and detecting centralized vs. distributed setup |
+| [references/sandbox-dev-configuration.md](references/sandbox-dev-configuration.md) | Finding or creating a dev sandbox instead of developing against production |
+| [references/cloning-template.md](references/cloning-template.md) | Naming convention and where/how to clone the starter template (or another existing app) |
+| [references/install-app.md](references/install-app.md) | Wiring the app into an engine/environment via a `dev` descriptor or `install_app`/`switch_app` |
+| [references/app-manifest.md](references/app-manifest.md) | `info.yml` manifest fields — engines, settings schema, frameworks, version requirements |
+| [references/app-hooks.md](references/app-hooks.md) | When and how to add a hook, and how studios override it per-project |
+| [references/implement-app.md](references/implement-app.md) | `app.py`/`dialog.py` structure, UI vs. no-UI paths, web menu actions, custom events |
+| [references/test-app.md](references/test-app.md) | Reload-and-Restart loop, `tk-shell`-first testing, granting testers sandbox access |
+| [references/release.md](references/release.md) | Versioning, tagging a release, and pushing config changes to production |
+| [references/centralized-config.md](references/centralized-config.md) | Access checks and on-disk layout for centralized (classic) pipeline configurations |
+| [references/distributed-config.md](references/distributed-config.md) | Descriptor types and what to do for each, for distributed pipeline configurations |
+| [references/python-api-best-practices.md](references/python-api-best-practices.md) | Performance, API-key hygiene, and design guidance for `sg.find`/`sg.create` calls |
+
 ## Flow PTR documentation
 
 - **User documentation** — getting-started guides and know-how articles by production role:

--- a/skills/flow-ptr-app/SKILL.md
+++ b/skills/flow-ptr-app/SKILL.md
@@ -5,22 +5,19 @@ description: "Guide for developing a new Flow Production Tracking (FPTR) / ShotG
 
 # Create a Flow Production Tracking (FPTR) Toolkit App
 
-Scaffolds a new Toolkit (`sgtk`) app for Flow Production Tracking (formerly ShotGrid/Shotgun)
-by forking Autodesk's official starter template, rather than building an app from scratch.
-
 This skill guides developers and pipeline engineers through building an FPTR app, following a
 **spec-driven** way — capture intent, check for reuse, write and validate a spec, plan, then
 implement, verify, release, and maintain against that spec. Tell the user which phase (below)
 you're starting before acting in it, so they can track progress and step in between phases.
 
 Reference guide: [Developing a Toolkit App](https://help.autodesk.com/view/SGDEV/ENU/?guid=SGD_pg_developer_pg_sgtk_developer_app_html)
-Template repo: https://github.com/shotgunsoftware/tk-multi-starterapp
+Default app template repo: https://github.com/shotgunsoftware/tk-multi-starterapp
 
 ## Overview
 
-The `## Step N` sections below (Step 0 through Step 9) hold the mechanical how-to for parts of
-Phases 1, 3–6, and 8. Phases 2, 7, and 9 have no dedicated section below — they're about the spec
-and process rather than a tool/config action, so they're covered inline above.
+The How-to guides below hold the mechanical how-to for parts of Phases 1, 3–6, and 8. Phases 2, 7,
+and 9 have no dedicated guide — they're about the spec and process rather than a tool/config
+action, so they're covered inline above.
 
 - **Phase 1 — Requirements/Intent capture**
    - Step 1.1 — Ask for the business need, and capture it in a short spec (one paragraph or a few
@@ -82,54 +79,45 @@ and process rather than a tool/config action, so they're covered inline above.
      during initial development.
 
 
-## Find existing apps
+# How-to guides
+
+## Find existing functionality or apps
 
 Toolkit has a customization ladder — cheaper options first:
 
 1. **Project settings** — often what looks like "custom behavior" is just a setting on an
    existing app (`env/includes/settings/...`).
 2. **App settings** — check the target app's `info.yml` for a setting that already does this.
-3. **Hooks** — the app may expose a hook for exactly the behavior you want to change.
+3. **Hooks** — the app may already expose a hook for exactly the behavior you want to change.
 4. **An existing app, mainstream or niche** — search for one (below) before assuming none exists.
    Fork/extend if it's close to what you need.
-5. **A brand-new app** — when nothing found that can be reused.
+5. **A brand-new app** — only once none of the above can be reused.
 
-Search in the shotgunsoftware org by keyword — name, description, and
-README** — the table below is a commonly-used subset, not the full catalog, so absence from it
-isn't proof nothing exists (e.g. "import an EDL and create cuts" matches `tk-multi-importcut`,
-not anything named "edl"):
+Best practice is to search the shotgunsoftware org by keyword — name, description, and README —
+before assuming nothing exists:
 ```bash
 curl -s "https://api.github.com/search/repositories?q=<keyword>+org:shotgunsoftware+in:name,description,readme" \
   | grep -o '"full_name": *"[^"]*"'
 ```
 (Use this `curl`/api.github.com form, not `gh api`, if `gh` is configured against an internal
-GitHub Enterprise host.) If you get a hit, confirm it's not archived, then go to Step 6's forking
-path instead of Step 3's template clone.
-
-| App | What it does |
-|---|---|
-| Panel | Lightweight FPTR overview inside the DCC (Maya, Nuke, Houdini, ...) — current task, activity stream, notes, tasks, versions, publishes, without leaving the app. |
-| About | Displays the current Toolkit context, config, and installed app/engine versions — debugging/support utility. |
-| Launch App | Shortcuts to start any supported application from the web or Desktop interface. |
-| Snapshot | Capture/restore the state of the current DCC scene as a local backup (not shared/published). |
-| Workfiles | Safely create, open, or version up workfiles tied to a task/asset/shot; can also start from an already-published file. |
-| Publish | Lets artists publish work for downstream use, with pre-publish validation and progress/logging; supports both in-DCC and standalone file publishing. |
-| Loader | Browse and load/reference published files into the current DCC, with a customizable, context-aware tree view. |
-| Breakdown | Tracks assets referenced in a scene and flags when newer published versions are available. |
+GitHub Enterprise host.) 
 
 Flame, Nuke, Hiero, Houdini, and Mari ship their own export/tracking apps too — check those the
-same way before scaffolding new. Editorial/cut-import workflows specifically are covered by
-`tk-multi-importcut` (https://github.com/shotgunsoftware/tk-multi-importcut) — an EDL/AAF import
-app that creates Cuts, CutItems, and Versions and links them to Sequences/Shots.
+same way before scaffolding new.
 
-- Full list of ready-to-use apps: https://help.autodesk.com/view/SGDEV/ENU/?guid=SGD_pc_toolkit_apps_html
+- A list of ready-to-use apps: https://help.autodesk.com/view/SGDEV/ENU/?guid=SGD_pc_toolkit_apps_html
 - All app/engine/framework source: https://github.com/shotgunsoftware
 
-## Step 1 — Locate the project configuration
+Before designing your own app's architecture, read
+[references/reference-apps.md](references/reference-apps.md) — real Autodesk-maintained apps,
+each demonstrating one distinct, reusable pattern (publish pipelines, hook-per-concern slicing,
+minimal single-hook apps, web menu actions).
+
+## Locating a project configuration
 
 Before anything else, find the `PipelineConfiguration` you'll actually be developing against, and
 figure out how it's set up. This determines where files live, whether there's a local `tank`
-command to run, and where the app's code goes in Step 3 — get this wrong and
+command to run, and where the app's code should be cloned to later — get this wrong and
 `install_app`/`switch_app` will look in the wrong place or fail outright.
 
 Check the project's **Pipeline Configurations** page in Flow Production Tracking, or query it via
@@ -145,11 +133,11 @@ sg.find_one(
 
 **Planning boundary:** this query (and reading the descriptor scheme below) is read-only and safe
 to run during a plan pass — it doesn't touch the filesystem or any repo. Almost everything else in
-this skill branches on what it returns (sandbox strategy, install method, and whether Step 1 itself
-ends in "blocked, escalate" for some descriptor types), so treat this lookup as the plan-phase
-action and draft the rest of the plan *after* it returns, rather than trying to plan the whole
-thing upfront. Everything from here on — cloning, write-access probes, `tank` commands — is the
-execute phase.
+this guide branches on what it returns (sandbox strategy, install method, and whether this lookup
+itself ends in "blocked, escalate" for some descriptor types), so best practice is to run this
+lookup first and draft the rest of the plan *after* it returns, rather than planning the whole
+thing upfront. Everything from here on — cloning, write-access probes, `tank` commands — is
+execution, not planning.
 
 - **Populated `mac_path`/`windows_path`/`linux_path`, no `descriptor`** → **centralized (classic)**
   configuration.
@@ -158,7 +146,7 @@ execute phase.
 **Centralized (classic):** the whole config lives at one fixed path shared by every machine. Read
 [references/centralized-config.md](references/centralized-config.md) before continuing — it covers
 the access checks you must run before touching that path, plus how sandboxing, cloning, and the
-final release descriptor (Steps 2, 3, and 9) differ for this config type.
+final release descriptor differ for this config type.
 
 **Distributed:** there's no single fixed install location — every machine resolves the `descriptor`
 on demand into its own local bundle cache. Read
@@ -166,36 +154,36 @@ on demand into its own local bundle cache. Read
 whole file, not just the descriptor-type table: some descriptor types (App Store, FPTR-attachment)
 carry escalation steps that are easy to miss if skipped.
 
-## Step 2 — Find or create a sandbox/dev configuration (strongly advised, not mandatory)
+## Find or create a sandbox/dev configuration (strongly advised, not mandatory)
 
-You *can* develop directly against the configuration located in Step 1, even if it's production —
+You *can* develop directly against the configuration you located above, even if it's production —
 Toolkit doesn't technically stop you. It's just a bad idea: a half-finished app can break real
 menus/commands for everyone else on the project, and any test data/events you generate land in
-production. Use a sandbox unless you have a specific reason not to.
+production. Best practice is to use a sandbox unless you have a specific reason not to.
 
 First check whether a dev sandbox already exists for this project — look for one already
 cloned/flagged for dev use on the Pipeline Configurations page, or ask the user directly. If one
-exists, skip to Step 3 and target it instead of production.
+exists, target it instead of production.
 
 If one doesn't exist yet, create it by following the "Creating a sandbox" section of whichever
-reference file you read in Step 1 —
+reference file matches the config type —
 [references/centralized-config.md](references/centralized-config.md) or
 [references/distributed-config.md](references/distributed-config.md). Either way, once you have a
-target configuration you also know where the app's own code should be cloned to in Step 3.
+target configuration you also know where the app's own code should be cloned to next.
 
-## Step 3 — Clone and rename the starter template
+## Cloning and renaming the starter template
 
-Name the app, following the `tk-ENGINE-APPNAME` convention:
+Apps are named following the `tk-ENGINE-APPNAME` convention:
 
 - `tk-multi-<appname>` if the app should run in more than one engine (Maya, 3ds Max, Nuke, Desktop, Shell, ...)
 - `tk-<engine>-<appname>` if it's tied to one DCC, e.g. `tk-maya-characterposer`
 
-**Ask where the app's source should be cloned to — don't assume.** The default target and clone
-command depend on config type — follow the "Cloning the app template" section of
-[references/centralized-config.md](references/centralized-config.md) or
-[references/distributed-config.md](references/distributed-config.md) (whichever matches Step 1),
-which also covers when the user might still prefer a separate workspace folder over the config-type
-default.
+**Best practice: ask where the app's source should be cloned to, rather than assuming.** The
+default target and clone command depend on config type — follow the "Cloning the app template"
+section of [references/centralized-config.md](references/centralized-config.md) or
+[references/distributed-config.md](references/distributed-config.md) (whichever matches the
+project's config type), which also covers when the user might still prefer a separate workspace
+folder over the config-type default.
 
 **Working from GitHub's UI:** fork https://github.com/shotgunsoftware/tk-multi-starterapp (or
 download it as a zip) into your own repo instead, then place/rename it per the reference file above.
@@ -213,7 +201,7 @@ resources/resources.qrc
 style.qss              # Qt stylesheet
 ```
 
-## Step 4 — Install the app into the target configuration
+## Install an app into the target configuration
 
 Pick the environment (e.g. `shot_step` for Shots, `asset_step` for Assets, or `project` if the app
 only needs project-level context) and the engine you're targeting (`tk-maya`, `tk-nuke`,
@@ -241,10 +229,11 @@ earlier in this skill's own dev session, wiring `tk-multi-eventAiCreated` into `
 `tk-desktop.yml` this way, with no git repo involved at all yet.
 
 `type: dev` is about the development workflow (it's what turns on the "Reload and Restart" menu
-command), not about *where* the code physically sits — `path:` just points at wherever Step 3 put
-it. So it's still `type: dev` whether that path is `<configuration_folder>/install/apps/<name>` or
-an external workspace folder; the type only changes once the app stops being actively developed
-and gets a real release descriptor (`git`/`app_store`/...) in Step 9.
+command), not about *where* the code physically sits — `path:` just points at wherever the app's
+source was cloned to. So it's still `type: dev` whether that path is
+`<configuration_folder>/install/apps/<name>` or an external workspace folder; the type only changes
+once the app stops being actively developed and gets a real release descriptor (`git`/`app_store`/
+...) — see "Release and push to production" below.
 
 **Alternative — `install_app` + `switch_app`:** useful once the app already has at least one git
 tag (e.g. it started life as an app-store/git app and you're now developing a new feature for it).
@@ -271,12 +260,12 @@ when reviewing the diff before `push_configuration`:
 - `env/includes/settings/tk-<engine>.yml` — wires the app into an engine + pipeline step
   (asset/shot/sequence/...); make sure the app's settings file is included at the top of this file
 
-> **Engine version:** when the environment config pins an engine (e.g. `tk-maya`), use the
-> latest available engine version for that environment rather than an old pinned one — you get
-> current bug fixes and it avoids chasing issues in the engine that have already been fixed
-> upstream.
+> **Engine version:** when the environment config pins an engine (e.g. `tk-maya`), best practice
+> is to use the latest available engine version for that environment rather than an old pinned
+> one — you get current bug fixes and it avoids chasing issues in the engine that have already
+> been fixed upstream.
 
-## Step 5 — Adjust `info.yml`
+## Adjust the app descriptor `info.yml`
 
 Update the manifest to describe the app and its configuration surface:
 
@@ -317,7 +306,7 @@ Read settings in code with `self.get_setting("save_template")` (inside `Applicat
 
 Manifest reference: https://developers.shotgridsoftware.com/tk-core/platform.html#manifest-file
 
-## Step 6 — Decide on hooks
+## App hooks
 
 Hooks let studios override specific pieces of app behavior per-project without touching the app's
 code — extract a piece of logic that's likely to need per-studio customization (path logic,
@@ -361,13 +350,13 @@ my_custom_app:
     version: v1.0.0
 ```
 
-When forking, use extended version numbers (`vBASE.LOCAL`, e.g. `v0.2.12.1`) to indicate "based on
-upstream v0.2.12, plus our local patch 1" — this keeps a clear trail back to the original version
-and makes it obvious the tag isn't an upstream release.
+When forking, best practice is to use extended version numbers (`vBASE.LOCAL`, e.g. `v0.2.12.1`) to
+indicate "based on upstream v0.2.12, plus our local patch 1" — this keeps a clear trail back to the
+original version and makes it obvious the tag isn't an upstream release.
 
 More on descriptors: https://developers.shotgridsoftware.com/tk-core/descriptor.html
 
-## Step 7 — Implement the app
+## Implement a Flow PTR app
 
 - `app.py`: `Application` subclass, registers menu command(s) via `self.engine.register_command(...)`.
 - `python/app/dialog.py`: dialog construction and callbacks.
@@ -386,7 +375,7 @@ More on descriptors: https://developers.shotgridsoftware.com/tk-core/descriptor.
   via `sgtk`/the engine). It may also need the **REST API** for cases outside a Python/DCC context
   (e.g. external services, non-Python integrations): https://developers.shotgridsoftware.com/rest-api/
 
-### If the app is a web menu action (`tk-shotgun` engine)
+### Web menu action (`tk-shotgun` engine)
 
 Apps launched from a right-click menu in the FPTR **web** UI (not from inside a DCC) run under the
 `tk-shotgun` engine, which behaves differently from DCC engines like `tk-maya`:
@@ -401,8 +390,9 @@ Apps launched from a right-click menu in the FPTR **web** UI (not from inside a 
 
 Implications: this requires FPTR Desktop to be installed and running, plus network connectivity
 for the API calls. Logging goes to the standard Toolkit log files, not the browser console — set
-`debug_logging: true` (see Step 5) while iterating. Don't confuse `tk-shotgun` with `tk-desktop`
-(the engine that runs *inside* the Desktop launcher itself) — they're different engines.
+`debug_logging: true` (see "Adjust the app descriptor `info.yml`" above) while iterating. Don't
+confuse `tk-shotgun` with `tk-desktop` (the engine that runs *inside* the Desktop launcher itself)
+— they're different engines.
 
 ### Triggering custom events
 
@@ -418,7 +408,7 @@ Before writing any non-trivial `sg.find`/`sg.create` calls, read
 API-key/script hygiene, and design guidance that's cheap to follow now and expensive to retrofit
 later. Skip only for trivial, one-off calls.
 
-## Step 8 — Test
+## Test an app
 
 - Iterate using Reload and Restart as above.
 - Ask whether to verify headless in `tk-shell` first before testing in the final DCC/engine, or go
@@ -433,7 +423,7 @@ later. Skip only for trivial, one-off calls.
   - https://developers.shotgridsoftware.com/python-api/
   - https://help.autodesk.com/view/SGDEV/ENU/?guid=SGD_py_python_api_overview_html
 
-## Step 9 — Release and push to production
+## Release and push to production
 
 An app must be versioned to be installed via a git/App Store/GitHub descriptor at all — Toolkit
 resolves `version:` against git tags, so every release needs one. Use semantic versioning
@@ -459,7 +449,7 @@ GitHub releases, or a Shotgun-uploaded attachment — pick whichever matches how
 distributes Toolkit apps.
 
 Descriptor choice for this final release step also differs by config type — see the "Release
-descriptor" note in whichever reference file you read in Step 1
+descriptor" note in whichever reference file matches the project's config type
 ([references/centralized-config.md](references/centralized-config.md) /
 [references/distributed-config.md](references/distributed-config.md)).
 
@@ -468,20 +458,7 @@ descriptor" note in whichever reference file you read in Step 1
 configs/core updates" to upgrade automatically, or use `tank` from the project's config, or the
 update API — whichever fits the studio's workflow.
 
-## Reference apps to study
-
-Before designing your own app's architecture, read
-[references/reference-apps.md](references/reference-apps.md) — real Autodesk-maintained apps,
-each demonstrating one distinct, reusable pattern (publish pipelines, hook-per-concern slicing,
-minimal single-hook apps, web menu actions).
-
-## After this skill
-
-Once the app is scaffolded, developed, and tested in the sandbox, come back for help wiring the
-final descriptor and reviewing the environment YAML diff before it's pushed to the production
-pipeline configuration.
-
-## Documentation starting points
+## Flow PTR documentation
 
 - **User documentation** — getting-started guides and know-how articles by production role:
   https://help.autodesk.com/view/SGSUB/ENU/

--- a/skills/flow-ptr-app/SKILL.md
+++ b/skills/flow-ptr-app/SKILL.md
@@ -13,20 +13,22 @@ you're starting before acting in it, so they can track progress and step in betw
 Reference guide: [Developing a Toolkit App](https://help.autodesk.com/view/SGDEV/ENU/?guid=SGD_pg_developer_pg_sgtk_developer_app_html)
 Default app template repo: https://github.com/shotgunsoftware/tk-multi-starterapp
 
-## Overview
+## App spec-driven lifecycle
 
-The How-to guides below hold the mechanical how-to for parts of Phases 1, 3–6, and 8. Phases 2, 7,
-and 9 have no dedicated guide — they're about the spec and process rather than a tool/config
-action, so they're covered inline above.
+Each step below that has mechanical how-to links to a `references/*.md` guide — read it while
+executing that step, not before; keep the skill itself light and pull in detail only when it's
+actually needed. Phases 2, 7, and 9 have no dedicated guide — they're about the spec and process
+rather than a tool/config action.
 
 - **Phase 1 — Requirements/Intent capture**
    - Step 1.1 — Ask for the business need, and capture it in a short spec (one paragraph or a few
      bullet points) — what the app should do, on which context and environment it will run,
      whether it needs a UI, whether it needs toolkit hooks, constraints and acceptance criteria.
    - Step 1.2 — Find if an existing app / project setting / hook cover fully or partially the
-     requirements (see [references/existing-functionality.md](references/existing-functionality.md)
-     for the reuse ladder and search steps), and confirm with the user whether later we will
-     fork/extend from that tool or scaffold a new app from the starter template.
+     requirements, and confirm with the user whether later we will fork/extend from that tool or
+     scaffold a new app from the starter template. Read
+     [references/existing-functionality.md](references/existing-functionality.md) while executing
+     this step.
 - **Phase 2 — Specification** — before cloning anything, write down what the app does:
    - Step 2.1 — Clarify the goal, the app name, dependencies on Flow PTR frameworks/engines, the
      environment the tool runs in (e.g. Sequence/Shot/Episode-specific), the entities involved, the
@@ -38,30 +40,41 @@ action, so they're covered inline above.
      of assuming an answer; only move to Phase 3 once the spec is complete and consistent.
 - **Phase 3 — Plan/Design**
    - Step 3.1 — Locate the project's pipeline configuration and figure out how it's set up
-     (centralized vs. distributed).
-   - Step 3.2 — Find or create a sandbox or a dev configuration if it doesn't exist.
+     (centralized vs. distributed). Read
+     [references/locating-config.md](references/locating-config.md) while executing this step.
+   - Step 3.2 — Find or create a sandbox or a dev configuration if it doesn't exist. Read
+     [references/sandbox-dev-configuration.md](references/sandbox-dev-configuration.md) while
+     executing this step.
    - Step 3.3 — Clarify where the app's source code should live, and how it will be installed into
-     the target configuration (dev path vs. install_app + switch_app).
+     the target configuration (dev path vs. install_app + switch_app). Read
+     [references/cloning-template.md](references/cloning-template.md) and
+     [references/install-app.md](references/install-app.md) while executing this step.
    - Step 3.4 — Break the spec into a technical plan: architecture decisions, file/module
      breakdown, sequencing of work, identification of risks or open questions. Where practical,
      decide to keep core logic separate from UI code (e.g. `app.py`/a logic module stays
      UI-agnostic, with `dialog.py` calling into it) — this is what lets Phase 6 exercise the tool
-     as a headless command in `tk-shell` before wiring up the dialog.
+     as a headless command in `tk-shell` before wiring up the dialog. Read
+     [references/implement-app.md](references/implement-app.md) while executing this step for how
+     that split plays out in code.
    - Step 3.5 — Split the plan into discrete, independently verifiable tasks/tickets, each with
      clear inputs/outputs and acceptance criteria, so that the work can be parallelized and
      tracked.
 - **Phase 4 — Scaffold**
    - Step 4.1 — Clone the reference tool — `tk-multi-starterapp` by default, or whichever existing
-     app Phase 1 found as a better fit.
+     app Phase 1 found as a better fit. Read
+     [references/cloning-template.md](references/cloning-template.md) while executing this step.
 - **Phase 5 — Implement against spec**
    - Step 5.1 — Fill in `info.yml` and implement code with main logic starting in `app.py` and UI
-     starting in `python/app/dialog.py`. Declare and implement hooks if applicable.
+     starting in `python/app/dialog.py`. Declare and implement hooks if applicable. Read
+     [references/app-manifest.md](references/app-manifest.md),
+     [references/app-hooks.md](references/app-hooks.md), and
+     [references/implement-app.md](references/implement-app.md) while executing this step.
 - **Phase 6 — Verify against spec**
    - Step 6.1 — Test and iterate using Toolkit's "Reload and Restart" menu item, checked against
      acceptance criteria, not just "does it run". If possible and it has a dependency on UI, test
      first in `tk-shell` or a batch context, then in tk-desktop and then in the target DCC engine,
      if applicable. If app is a Menu Action Item, test it in the FPTR Desktop and then in the web
-     UI.
+     UI. Read [references/test-app.md](references/test-app.md) while executing this step.
 - **Phase 7 — Change management**
    - Step 7.1 — Commit in git, pushing changes only to the sandbox configuration, not
      production.
@@ -72,349 +85,13 @@ action, so they're covered inline above.
    - Step 8.1 — Once ready for release, warn the user about the implications of bringing to
      production the new changes. Analyse possible side effects or interruptions to workflow.
    - Step 8.2 — Tag a release and push the sandbox config changes to the production pipeline
-     configuration.
+     configuration. Read [references/release.md](references/release.md) while executing this
+     step.
 - **Phase 9 — Maintenance**
    - Step 9.1 — Treat post-release bug reports or new asks as spec changes, not code patches: update
      the spec first (back to Phase 2), validate it again, then re-enter Phase 3 and cascade forward
      through Phases 4-8 — the spec stays the source of truth for the life of the app, not just
      during initial development.
-
-
-# How-to guides
-
-## Find existing functionality or apps
-
-Toolkit has a customization ladder — cheaper options first: project settings, app settings, hooks,
-an existing app (fork/extend it), and only then a brand-new app. Read
-[references/existing-functionality.md](references/existing-functionality.md) before scaffolding
-anything — it covers where/how to search for existing apps and settings, real apps to study for
-architecture patterns, and how to fork one if you go that route.
-
-## Locating a project configuration
-
-Before anything else, find the `PipelineConfiguration` you'll actually be developing against, and
-figure out how it's set up. This determines where files live, whether there's a local `tank`
-command to run, and where the app's code should be cloned to later — get this wrong and
-`install_app`/`switch_app` will look in the wrong place or fail outright.
-
-Check the project's **Pipeline Configurations** page in Flow Production Tracking, or query it via
-the API:
-
-```python
-sg.find_one(
-    "PipelineConfiguration",
-    [["project", "is", {"type": "Project", "id": PROJECT_ID}], ["code", "is", "Primary"]],
-    ["mac_path", "windows_path", "linux_path", "descriptor"],
-)
-```
-
-**Planning boundary:** this query (and reading the descriptor scheme below) is read-only and safe
-to run during a plan pass — it doesn't touch the filesystem or any repo. Almost everything else in
-this guide branches on what it returns (sandbox strategy, install method, and whether this lookup
-itself ends in "blocked, escalate" for some descriptor types), so best practice is to run this
-lookup first and draft the rest of the plan *after* it returns, rather than planning the whole
-thing upfront. Everything from here on — cloning, write-access probes, `tank` commands — is
-execution, not planning.
-
-- **Populated `mac_path`/`windows_path`/`linux_path`, no `descriptor`** → **centralized (classic)**
-  configuration.
-- **Populated `descriptor`, empty path fields** → **distributed** configuration.
-
-**Centralized (classic):** the whole config lives at one fixed path shared by every machine. Read
-[references/centralized-config.md](references/centralized-config.md) before continuing — it covers
-the access checks you must run before touching that path, plus how sandboxing, cloning, and the
-final release descriptor differ for this config type.
-
-**Distributed:** there's no single fixed install location — every machine resolves the `descriptor`
-on demand into its own local bundle cache. Read
-[references/distributed-config.md](references/distributed-config.md) before continuing — read the
-whole file, not just the descriptor-type table: some descriptor types (App Store, FPTR-attachment)
-carry escalation steps that are easy to miss if skipped.
-
-## Find or create a sandbox/dev configuration (strongly advised, not mandatory)
-
-You *can* develop directly against the project's production configuration instead of a sandbox —
-Toolkit doesn't technically stop you. It's just a bad idea: a half-finished app can break real
-menus/commands for everyone else on the project, and any test data/events you generate land in
-production. Best practice is to use a sandbox unless you have a specific reason not to.
-
-First check whether a dev sandbox already exists for this project — look for one already
-cloned/flagged for dev use on the Pipeline Configurations page, or ask the user directly. If one
-exists, target it instead of production.
-
-If one doesn't exist yet, create it by following the "Creating a sandbox" section of whichever
-reference file matches the config type —
-[references/centralized-config.md](references/centralized-config.md) or
-[references/distributed-config.md](references/distributed-config.md). Either way, once you have a
-target configuration you also know where the app's own code should be cloned to next.
-
-## Cloning and renaming the starter template
-
-Apps are named following the `tk-ENGINE-APPNAME` convention:
-
-- `tk-multi-<appname>` if the app should run in more than one engine (Maya, 3ds Max, Nuke, Desktop, Shell, ...)
-- `tk-<engine>-<appname>` if it's tied to one DCC, e.g. `tk-maya-characterposer`
-
-**Best practice: ask where the app's source should be cloned to, rather than assuming.** The
-default target and clone command depend on config type — follow the "Cloning the app template"
-section of [references/centralized-config.md](references/centralized-config.md) or
-[references/distributed-config.md](references/distributed-config.md) (whichever matches the
-project's config type), which also covers when the user might still prefer a separate workspace
-folder over the config-type default.
-
-**Working from GitHub's UI:** fork https://github.com/shotgunsoftware/tk-multi-starterapp (or
-download it as a zip) into your own repo instead, then place/rename it per the reference file above.
-
-The template already ships with:
-
-```
-app.py                 # Application entry point, registers menu commands
-info.yml               # Manifest: metadata, settings schema, frameworks, version requirements
-python/app/__init__.py
-python/app/dialog.py   # Main window logic / callbacks
-python/app/ui/         # Auto-generated from resources/dialog.ui (pyside2-uic / build_resources.yml)
-resources/dialog.ui    # Qt Designer source for the UI
-resources/resources.qrc
-style.qss              # Qt stylesheet
-```
-
-## Install an app into the target configuration
-
-Pick the environment (e.g. `shot_step` for Shots, `asset_step` for Assets, or `project` if the app
-only needs project-level context) and the engine you're targeting (`tk-maya`, `tk-nuke`,
-`tk-desktop`, `tk-shell`, ...). Starting with the `tk-shell` engine in the `project` environment is
-often the fastest loop for early logic-only development (no DCC startup required, and you can run
-it straight from the command line or your IDE if you have a centralized config) — you can wire up
-DCC-specific UI/menus afterwards.
-
-**Fastest path — a `dev` location descriptor directly (no git tag needed yet):** a brand-new app
-has no git tag to `install_app` from anyway, so for early development just hand-edit the
-environment YAML and point the app straight at your local checkout:
-
-```yaml
-tk-multi-myapp:
-  location:
-    type: dev
-    path: /path/to/source_code/tk-multi-myapp
-```
-
-This goes wherever the app is wired into an engine's settings (e.g.
-`env/includes/settings/tk-shell.yml`'s `apps:` block for the environment you picked). Toolkit loads
-the code directly from that path, so every edit is picked up on the next reload — no reinstall
-step, and no git repo is needed yet.
-
-`type: dev` is about the development workflow (it's what turns on the "Reload and Restart" menu
-command), not about *where* the code physically sits — `path:` just points at wherever the app's
-source was cloned to. So it's still `type: dev` whether that path is
-`<configuration_folder>/install/apps/<name>` or an external workspace folder; the type only changes
-once the app stops being actively developed and gets a real release descriptor (`git`/`app_store`/
-...) — see "Release and push to production".
-
-**Alternative — `install_app` + `switch_app`:** useful once the app already has at least one git
-tag (e.g. it started life as an app-store/git app and you're now developing a new feature for it).
-From a shell, `cd` into the sandbox and use its `tank` command:
-
-```bash
-cd /your/development/sandbox
-./tank install_app shot_step tk-maya user@remotehost:/path_to/tk-multi-mynewapp.git
-```
-
-This installs the latest git tag. Launch the DCC from the sandbox against a Shot/Asset task to
-confirm the app loads. Then switch Toolkit to track your local checkout instead of the git tag, so
-code edits are picked up immediately — this produces the same `type: dev` location entry as the
-fastest-path option above, just generated for you rather than hand-written:
-
-```bash
-./tank switch_app shot_step tk-maya tk-multi-mynewapp /Users/you/dev/tk-multi-mynewapp
-```
-
-Either way, these are the files under the sandbox's config that end up changed — useful to know
-when reviewing the diff before `push_configuration`:
-- `env/includes/app_locations.yml` — where Toolkit finds the app's code (git repo, local path, etc.)
-- `env/includes/settings/<my_custom_app>.yml` — the app's own settings for this project
-- `env/includes/settings/tk-<engine>.yml` — wires the app into an engine + pipeline step
-  (asset/shot/sequence/...); make sure the app's settings file is included at the top of this file
-
-> **Engine version:** when the environment config pins an engine (e.g. `tk-maya`), best practice
-> is to use the latest available engine version for that environment rather than an old pinned
-> one — you get current bug fixes and it avoids chasing issues in the engine that have already
-> been fixed upstream.
-
-## Adjust the app descriptor `info.yml`
-
-Update the manifest to describe the app and its configuration surface:
-
-```yaml
-display_name: "My New App"
-description: "What this app does."
-
-supported_engines:            # leave empty/omit if engine-agnostic
-requires_shotgun_fields:      # PTR entity fields this app depends on, if any
-requires_core_version: "v0.19.18"
-requires_engine_version:      # minimum engine version needed, if any (leave empty unless required)
-deny_permissions:             # restrict which PTR roles/groups can run this app, if needed
-deny_platform:                # restrict OS platforms, if needed
-help_url:                     # URL opened by the app's "help" button, if any
-
-configuration:
-  save_template:
-    type: template
-    default_value: "maya_asset_work"
-    description: "The template to use when building the path to save the file into"
-    allows_empty: False
-  debug_logging:
-    type: bool
-    default_value: false
-    description: "Controls whether debug logging is enabled for this app."
-
-frameworks:
-  - {"name": "tk-framework-shotgunutils", "version": "v2.x.x"}
-  - {"name": "tk-framework-qtwidgets", "version": "v1.x.x", "minimum_version": "v1.5.0"}
-```
-
-`entity_types` is another common setting (which PTR entity types the app applies to — Shots,
-Assets, Versions, ...) and `templates` lets a setting reference a filesystem template instead of
-a literal value/path.
-
-Read settings in code with `self.get_setting("save_template")` (inside `Application`) or
-`app.get_setting(...)` from the dialog module.
-
-Manifest reference: https://developers.shotgridsoftware.com/tk-core/platform.html#manifest-file
-
-## App hooks
-
-Hooks let studios override specific pieces of app behavior per-project without touching the app's
-code — extract a piece of logic that's likely to need per-studio customization (path logic,
-naming, validation rules) into its own hook. Only add one when that's actually likely; most simple
-apps need zero custom hooks.
-
-Declare each hook in `info.yml`'s `configuration` block, and ship the default implementation as its
-own `.py` file (with a `Hook` class) under a `hooks/` folder at the app's code root:
-
-```yaml
-configuration:
-  my_custom_hook:
-    type: hook
-    default_value: "{self}/my_custom_hook.py"
-    description: "Hook to customize X behavior."
-```
-
-**Studios override it** by copying the default hook file into the project config's `hooks/` folder
-(e.g. `my_project_config/config/hooks/my_custom_hook.py`), editing it there, then repointing the
-environment YAML setting at the copy:
-
-```yaml
-hook_before_app_launch: default              # built-in hook
-hook_before_app_launch: before_app_launch    # <- studio's custom copy
-```
-
-Common generic hook names you'll see across apps (useful naming inspiration for your own):
-`hook_before_app_launch`, `hook_app_launch`, `pick_environment`, `hook_before_register_command`,
-`hook_ui_config`, `actions_hook`, `post_load`.
-
-## Implement a Flow PTR app
-
-- `app.py`: `Application` subclass, registers menu command(s) via `self.engine.register_command(...)`.
-- `python/app/dialog.py`: dialog construction and callbacks.
-- Support **both** UI and no-UI execution paths, since not every engine/context has Qt available:
-  - **With UI**: full Qt window via `self.engine.show_dialog(...)` (PySide2/PySide6 or PyQt).
-  - **Without UI**: a console-only code path (check `self.engine.has_ui`) so the app still works
-    headlessly, e.g. under `tk-shell` or a batch/farm context.
-  - Qt bindings (PySide/PyQt) must be available in whichever Python environment runs the DCP/engine
-    — install PySide2/PySide6 (or PyQt) into that environment if it's missing.
-- As soon as the config has one or more `dev`-descriptor apps in it, Toolkit adds a **Reload and
-  Restart** entry to the PTR menu — use it to pick up code and config changes without restarting
-  the host application. It reloads the config and code and restarts the engine, but any app UI
-  already open on screen does **not** auto-update — close and re-launch it from the menu after
-  reloading to see your changes.
-- App logic will mainly talk to PTR through the **Python API** (`shotgun_api3`, already available
-  via `sgtk`/the engine). It may also need the **REST API** for cases outside a Python/DCC context
-  (e.g. external services, non-Python integrations): https://developers.shotgridsoftware.com/rest-api/
-
-### Web menu action (`tk-shotgun` engine)
-
-Apps launched from a right-click menu in the FPTR **web** UI (not from inside a DCC) run under the
-`tk-shotgun` engine, which behaves differently from DCC engines like `tk-maya`:
-
-1. Clicking the menu action in the browser sends a request to FPTR Desktop.
-2. Desktop spawns a separate local Python process and bootstraps the `tk-shotgun` engine in it.
-3. Your app code runs in that process — same idea as `python script.py` from the command line,
-   but with the Toolkit framework loaded.
-4. If UI is needed, a Qt app starts there (same with-UI/without-UI detection as above).
-5. All output is captured and sent back to the web interface **only after the process
-   completes** — it is not streamed live.
-
-Implications: this requires FPTR Desktop to be installed and running, plus network connectivity
-for the API calls. Logging goes to the standard Toolkit log files, not the browser console — set
-`debug_logging: true` (see "Adjust the app descriptor `info.yml`") while iterating. Don't
-confuse `tk-shotgun` with `tk-desktop` (the engine that runs *inside* the Desktop launcher itself)
-— they're different engines.
-
-### Triggering custom events
-
-If other systems (the studio's Event Framework daemon, webhooks) should react to something your
-app does, create an `EventLogEntry` yourself via the Python API, e.g.
-`sg.create("EventLogEntry", data)`, using the same naming convention FPTR uses internally:
-`ApplicationName_EntityType_Action` (e.g. `tkMultiEventApp_event_new`).
-
-### Python API best practices
-
-Before writing any non-trivial `sg.find`/`sg.create` calls, read
-[references/python-api-best-practices.md](references/python-api-best-practices.md) — performance,
-API-key/script hygiene, and design guidance that's cheap to follow now and expensive to retrofit
-later. Skip only for trivial, one-off calls.
-
-## Test an app
-
-- Iterate using Toolkit's **Reload and Restart** menu item to pick up code and config changes
-  without restarting the host application (see "Implement a Flow PTR app" for what enables it and
-  its limits).
-- Ask whether to verify headless in `tk-shell` first before testing in the final DCC/engine, or go
-  straight to the final target — `tk-shell` first gives a faster logic-only loop (no DCC startup)
-  and catches non-UI bugs early, but ultimately the dialog/UI still needs to be confirmed working
-  in the real target engine (`tk-desktop` or the DCC itself) before calling it tested.
-- To bring in another tester without giving them production access, add them to the
-  **User Restrictions** field on the sandbox's `PipelineConfiguration` entity in PTR, and make sure
-  they have read access to your app's repo/checkout.
-- The Python API is useful for writing quick test scripts or exercising app logic against real
-  PTR data outside the DCC:
-  - https://developers.shotgridsoftware.com/python-api/
-  - https://help.autodesk.com/view/SGDEV/ENU/?guid=SGD_py_python_api_overview_html
-
-## Release and push to production
-
-An app must be versioned to be installed via a git/App Store/GitHub descriptor at all — Toolkit
-resolves `version:` against git tags, so every release needs one. Use semantic versioning
-(`vMAJOR.MINOR.PATCH`, e.g. start at `v0.1.0` during early development, `v1.0.0` for the first
-production-ready release) and bump it for every change you want the config to be able to pin to.
-
-Tag a version in git (e.g. `v1.0.0`), then switch the sandbox back from dev mode to the tagged
-git descriptor:
-
-```bash
-./tank switch_app shot_step tk-maya tk-multi-mynewapp user@remotehost:/path_to/tk-multi-mynewapp.git
-```
-
-Toolkit will pick up the highest-numbered tag. Finally, push the sandbox's config changes to the
-project's primary production configuration:
-
-```bash
-./tank push_configuration
-```
-
-Other descriptor types are available for the final `location` entry besides a git tag — App Store,
-GitHub releases, or a Shotgun-uploaded attachment — pick whichever matches how the studio
-distributes Toolkit apps.
-
-Descriptor choice for this final release step also differs by config type — see the "Release
-descriptor" note in whichever reference file matches the project's config type
-([references/centralized-config.md](references/centralized-config.md) /
-[references/distributed-config.md](references/distributed-config.md)).
-
-**Later, when you ship a new version:** bump the version manually in `app_locations.yml` (and
-`core_api.yml` if it's a core update), or use the Desktop app's Project menu → "Check for
-configs/core updates" to upgrade automatically, or use `tank` from the project's config, or the
-update API — whichever fits the studio's workflow.
 
 ## Flow PTR documentation
 

--- a/skills/flow-ptr-app/references/app-hooks.md
+++ b/skills/flow-ptr-app/references/app-hooks.md
@@ -1,0 +1,30 @@
+# App hooks
+
+Hooks let studios override specific pieces of app behavior per-project without touching the app's
+code — extract a piece of logic that's likely to need per-studio customization (path logic,
+naming, validation rules) into its own hook. Only add one when that's actually likely; most simple
+apps need zero custom hooks.
+
+Declare each hook in `info.yml`'s `configuration` block, and ship the default implementation as its
+own `.py` file (with a `Hook` class) under a `hooks/` folder at the app's code root:
+
+```yaml
+configuration:
+  my_custom_hook:
+    type: hook
+    default_value: "{self}/my_custom_hook.py"
+    description: "Hook to customize X behavior."
+```
+
+**Studios override it** by copying the default hook file into the project config's `hooks/` folder
+(e.g. `my_project_config/config/hooks/my_custom_hook.py`), editing it there, then repointing the
+environment YAML setting at the copy:
+
+```yaml
+hook_before_app_launch: default              # built-in hook
+hook_before_app_launch: before_app_launch    # <- studio's custom copy
+```
+
+Common generic hook names you'll see across apps (useful naming inspiration for your own):
+`hook_before_app_launch`, `hook_app_launch`, `pick_environment`, `hook_before_register_command`,
+`hook_ui_config`, `actions_hook`, `post_load`.

--- a/skills/flow-ptr-app/references/app-manifest.md
+++ b/skills/flow-ptr-app/references/app-manifest.md
@@ -34,6 +34,12 @@ frameworks:
 Assets, Versions, ...) and `templates` lets a setting reference a filesystem template instead of
 a literal value/path.
 
+> **Core version:** don't copy the example value verbatim — check what core the target project is
+> actually running (`./tank core` from the config, or its `install/core/core_api.yml`) and pin to
+> that. Requiring a newer core than the project has deployed forces a core upgrade before this app
+> can be installed at all, so confirm with the user before bumping `requires_core_version` past
+> what's currently running.
+
 Read settings in code with `self.get_setting("save_template")` (inside `Application`) or
 `app.get_setting(...)` from the dialog module.
 

--- a/skills/flow-ptr-app/references/app-manifest.md
+++ b/skills/flow-ptr-app/references/app-manifest.md
@@ -1,0 +1,40 @@
+# Adjust the app manifest, `info.yml`
+
+Update the manifest to describe the app and its configuration surface:
+
+```yaml
+display_name: "My New App"
+description: "What this app does."
+
+supported_engines:            # leave empty/omit if engine-agnostic
+requires_shotgun_fields:      # PTR entity fields this app depends on, if any
+requires_core_version: "v0.19.18"
+requires_engine_version:      # minimum engine version needed, if any (leave empty unless required)
+deny_permissions:             # restrict which PTR roles/groups can run this app, if needed
+deny_platform:                # restrict OS platforms, if needed
+help_url:                     # URL opened by the app's "help" button, if any
+
+configuration:
+  save_template:
+    type: template
+    default_value: "maya_asset_work"
+    description: "The template to use when building the path to save the file into"
+    allows_empty: False
+  debug_logging:
+    type: bool
+    default_value: false
+    description: "Controls whether debug logging is enabled for this app."
+
+frameworks:
+  - {"name": "tk-framework-shotgunutils", "version": "v2.x.x"}
+  - {"name": "tk-framework-qtwidgets", "version": "v1.x.x", "minimum_version": "v1.5.0"}
+```
+
+`entity_types` is another common setting (which PTR entity types the app applies to — Shots,
+Assets, Versions, ...) and `templates` lets a setting reference a filesystem template instead of
+a literal value/path.
+
+Read settings in code with `self.get_setting("save_template")` (inside `Application`) or
+`app.get_setting(...)` from the dialog module.
+
+Manifest reference: https://developers.shotgridsoftware.com/tk-core/platform.html#manifest-file

--- a/skills/flow-ptr-app/references/centralized-config.md
+++ b/skills/flow-ptr-app/references/centralized-config.md
@@ -1,0 +1,62 @@
+# Centralized (classic) pipeline configuration
+
+Everything Steps 1-3 and 9 of SKILL.md do differently when the `PipelineConfiguration`'s
+`mac_path`/`windows_path`/`linux_path` fields are populated and `descriptor` is empty.
+
+## What it looks like
+
+The whole config — `config/`, `install/` (core, plus every app/engine/framework it has ever
+resolved), `cache/`, and the `tank`/`tank.bat` scripts — lives at one fixed path on disk, the same
+path on every machine that uses it. This is what we used earlier in this skill's own dev session:
+
+```
+/Users/<username>/dev/FlowPTR/config/my_dev_config
+├── tank / tank.bat
+├── config/env/...
+└── install/apps/...       # apps get vendored in here the first time they're installed
+```
+
+`cd` into that path and run `./tank ...` directly for every `tank` command referenced elsewhere in
+this skill.
+
+## Before touching the path: check access
+
+Confirm you (the coding agent) can both see and write to that path — a centralized config's fixed
+location is often outside where the agent normally operates, and visibility doesn't imply write
+access. Two distinct problems need distinct fixes:
+
+- **Out of workspace scope:** if a plain read (`ls`) is refused as *out of scope* rather than an OS
+  error, ask whoever's driving the session to add that path as an additional working directory.
+- **No write permission:** once in scope, confirm you can also write
+  (`touch <path>/.write_test && rm <path>/.write_test`) — read-only access is common on shared
+  configs. If write fails, don't chase wider permissions — build your own sandbox instead (below),
+  which you'll own outright. Re-run both checks against the sandbox if it also turns out to be
+  unwritable.
+
+## Creating a sandbox (Step 2)
+
+Right-click the primary config on the Pipeline Configurations page and **Clone** it. This produces
+a second `PipelineConfiguration` entity with its own path fields and an on-disk copy with the same
+`config/`/`install/`/`tank` structure described above — that copy is your sandbox.
+
+## Cloning the app template (Step 3)
+
+Default target is under the config itself, at `install/apps/<name>` — this is the best-practice
+location, though the user may still prefer a separate workspace folder to keep the app's own repo
+independent of the config from day one; confirm which one before cloning.
+
+```bash
+git clone https://github.com/shotgunsoftware/tk-multi-starterapp.git \
+  <configuration_folder>/install/apps/tk-multi-myapp
+cd <configuration_folder>/install/apps/tk-multi-myapp
+rm -rf .git
+git init
+git remote add origin <your-studio-repo-url>   # once you have a destination to push to
+```
+
+e.g. `/mnt/pipeline/my_project/config/install/apps/tk-multi-myapp`.
+
+## Release descriptor (Step 9)
+
+A git descriptor works well here — one admin runs the update and the resolved code is cached once,
+in a location every user already shares.

--- a/skills/flow-ptr-app/references/centralized-config.md
+++ b/skills/flow-ptr-app/references/centralized-config.md
@@ -6,7 +6,7 @@
 
 The whole config — `config/`, `install/` (core, plus every app/engine/framework it has ever
 resolved), `cache/`, and the `tank`/`tank.bat` scripts — lives at one fixed path on disk, the same
-path on every machine that uses it. This is what we used earlier in this skill's own dev session:
+path on every machine that uses it. For example:
 
 ```
 /Users/<username>/dev/FlowPTR/config/my_dev_config

--- a/skills/flow-ptr-app/references/centralized-config.md
+++ b/skills/flow-ptr-app/references/centralized-config.md
@@ -1,7 +1,6 @@
 # Centralized (classic) pipeline configuration
 
-Everything Steps 1-3 and 9 of SKILL.md do differently when the `PipelineConfiguration`'s
-`mac_path`/`windows_path`/`linux_path` fields are populated and `descriptor` is empty.
+`PipelineConfiguration`'s `mac_path`/`windows_path`/`linux_path` fields are populated and `descriptor` is empty.
 
 ## What it looks like
 
@@ -13,11 +12,17 @@ path on every machine that uses it. This is what we used earlier in this skill's
 /Users/<username>/dev/FlowPTR/config/my_dev_config
 ├── tank / tank.bat
 ├── config/env/...
-└── install/apps/...       # apps get vendored in here the first time they're installed
+└── install/
+    ├── app_store/...       # git/app_store descriptors resolve here automatically — not for hand-editing
+    └── apps/...            # reserved for your own dev-type apps (see cloning-template.md)
 ```
 
 `cd` into that path and run `./tank ...` directly for every `tank` command referenced elsewhere in
 this skill.
+
+Note `install/app_store/` isn't fixed to that name — the actual bundle-cache location on disk is
+whatever a `dev`/`app_store`/`git` descriptor in `env/includes/app_locations.yml` resolves to; an
+app can live anywhere as long as its descriptor points there.
 
 ## Before touching the path: check access
 
@@ -29,34 +34,6 @@ access. Two distinct problems need distinct fixes:
   error, ask whoever's driving the session to add that path as an additional working directory.
 - **No write permission:** once in scope, confirm you can also write
   (`touch <path>/.write_test && rm <path>/.write_test`) — read-only access is common on shared
-  configs. If write fails, don't chase wider permissions — build your own sandbox instead (below),
-  which you'll own outright. Re-run both checks against the sandbox if it also turns out to be
-  unwritable.
-
-## Creating a sandbox (Step 2)
-
-Right-click the primary config on the Pipeline Configurations page and **Clone** it. This produces
-a second `PipelineConfiguration` entity with its own path fields and an on-disk copy with the same
-`config/`/`install/`/`tank` structure described above — that copy is your sandbox.
-
-## Cloning the app template (Step 3)
-
-Default target is under the config itself, at `install/apps/<name>` — this is the best-practice
-location, though the user may still prefer a separate workspace folder to keep the app's own repo
-independent of the config from day one; confirm which one before cloning.
-
-```bash
-git clone https://github.com/shotgunsoftware/tk-multi-starterapp.git \
-  <configuration_folder>/install/apps/tk-multi-myapp
-cd <configuration_folder>/install/apps/tk-multi-myapp
-rm -rf .git
-git init
-git remote add origin <your-studio-repo-url>   # once you have a destination to push to
-```
-
-e.g. `/mnt/pipeline/my_project/config/install/apps/tk-multi-myapp`.
-
-## Release descriptor (Step 9)
-
-A git descriptor works well here — one admin runs the update and the resolved code is cached once,
-in a location every user already shares.
+  configs. If write fails, don't chase wider permissions — build your own sandbox instead (see
+  [sandbox-dev-configuration.md](sandbox-dev-configuration.md)), which you'll own outright. Re-run
+  both checks against the sandbox if it also turns out to be unwritable.

--- a/skills/flow-ptr-app/references/cloning-template.md
+++ b/skills/flow-ptr-app/references/cloning-template.md
@@ -6,14 +6,45 @@ Apps are named following the `tk-ENGINE-APPNAME` convention:
 - `tk-<engine>-<appname>` if it's tied to one DCC, e.g. `tk-maya-characterposer`
 
 **Best practice: ask where the app's source should be cloned to, rather than assuming.** The
-default target and clone command depend on config type — follow the "Cloning the app template"
-section of [centralized-config.md](centralized-config.md) or
-[distributed-config.md](distributed-config.md) (whichever matches the project's config type),
-which also covers when the user might still prefer a separate workspace folder over the config-type
-default.
+default target and clone command depend on the project's config type (see
+[locating-config.md](locating-config.md) if you haven't determined that yet):
+
+## Centralized config
+
+Default target is under the config itself, at `install/apps/<name>` — this is the best-practice
+location, though the user may still prefer a separate workspace folder to keep the app's own repo
+independent of the config from day one, or because they intend to reuse the app across more than
+one project; confirm which one before cloning.
+
+```bash
+git clone https://github.com/shotgunsoftware/tk-multi-starterapp.git \
+  <configuration_folder>/install/apps/tk-multi-myapp
+cd <configuration_folder>/install/apps/tk-multi-myapp
+rm -rf .git
+git init
+git remote add origin <your-studio-repo-url>   # once you have a destination to push to
+```
+
+e.g. `/mnt/pipeline/my_project/config/install/apps/tk-multi-myapp`. See
+[centralized-config.md](centralized-config.md) for more on this layout.
+
+## Distributed config
+
+No local `install/apps` to drop code into — clone into a regular dev workspace folder, and wire it
+in later via `switch_app`/a `dev` descriptor (see [install-app.md](install-app.md)):
+
+```bash
+git clone https://github.com/shotgunsoftware/tk-multi-starterapp.git tk-multi-myapp
+cd tk-multi-myapp
+rm -rf .git
+git init
+git remote add origin <your-studio-repo-url>   # once you have a destination to push to
+```
+
+See [distributed-config.md](distributed-config.md) for more on this layout.
 
 **Working from GitHub's UI:** fork https://github.com/shotgunsoftware/tk-multi-starterapp (or
-download it as a zip) into your own repo instead, then place/rename it per the reference file above.
+download it as a zip) into your own repo instead, then place/rename it per the sections above.
 
 The template already ships with:
 

--- a/skills/flow-ptr-app/references/cloning-template.md
+++ b/skills/flow-ptr-app/references/cloning-template.md
@@ -1,0 +1,29 @@
+# Cloning and renaming the starter template
+
+Apps are named following the `tk-ENGINE-APPNAME` convention:
+
+- `tk-multi-<appname>` if the app should run in more than one engine (Maya, 3ds Max, Nuke, Desktop, Shell, ...)
+- `tk-<engine>-<appname>` if it's tied to one DCC, e.g. `tk-maya-characterposer`
+
+**Best practice: ask where the app's source should be cloned to, rather than assuming.** The
+default target and clone command depend on config type — follow the "Cloning the app template"
+section of [centralized-config.md](centralized-config.md) or
+[distributed-config.md](distributed-config.md) (whichever matches the project's config type),
+which also covers when the user might still prefer a separate workspace folder over the config-type
+default.
+
+**Working from GitHub's UI:** fork https://github.com/shotgunsoftware/tk-multi-starterapp (or
+download it as a zip) into your own repo instead, then place/rename it per the reference file above.
+
+The template already ships with:
+
+```
+app.py                 # Application entry point, registers menu commands
+info.yml               # Manifest: metadata, settings schema, frameworks, version requirements
+python/app/__init__.py
+python/app/dialog.py   # Main window logic / callbacks
+python/app/ui/         # Auto-generated from resources/dialog.ui (pyside2-uic / build_resources.yml)
+resources/dialog.ui    # Qt Designer source for the UI
+resources/resources.qrc
+style.qss              # Qt stylesheet
+```

--- a/skills/flow-ptr-app/references/distributed-config.md
+++ b/skills/flow-ptr-app/references/distributed-config.md
@@ -1,7 +1,6 @@
 # Distributed pipeline configuration
 
-Everything Steps 1-3 and 9 of SKILL.md do differently when the `PipelineConfiguration`'s
-`descriptor` field is populated and the path fields are empty.
+`PipelineConfiguration`'s `descriptor` field is populated and the path fields are empty.
 
 ## What it looks like
 
@@ -24,42 +23,4 @@ that are easy to miss if you only skim for the clone command:
 | `git?path=<url>&version=<tag>` / `git_branch?path=<url>&branch=<branch>` | Git-based; `path=` is the clone URL | `git clone <path> my-dev-config`. Auth failure → ask the repo owner/admin for read access (and write/contributor access too if you'll push back). Can clone but can't push → fork/branch to something you own, point a personal `PipelineConfiguration` at it, and PR back later — good practice even with push access, to avoid disrupting teammates on the same descriptor. No git credentials configured at all → that's an environment setup issue for the user, not a permissions one. |
 | `app_store?name=<config>&version=<version>` | Packaged release downloaded into each user's bundle cache — not a repo, not editable | Any local edit is discarded on re-resolve. Check whether the studio already forked this into an editable git-backed config (look for another `PipelineConfiguration` pointing at that fork). If none exists, moving production off an App Store descriptor is an infrastructure decision — **escalate to the pipeline lead/admin rather than doing it unilaterally.** |
 | `path?path=<location>` | Plain shared folder, not git-versioned | Treat like the centralized case (see `references/centralized-config.md`) — check read *and* write access directly on the path. |
-| `shotgun?...` | Attachment on an FPTR entity — no repo, no branch/fork/PR mechanism | Download the current attachment (web UI, or `sg.download_attachment(...)`), confirm it's the latest version, and treat that unzipped folder as your one working copy — develop against it like the centralized case (Step 3 of SKILL.md). Put it under git yourself for a diff/rollback safety net. Confirm you have write access on the field before assuming you can `sg.upload(...)` a new version back. |
-
-## Creating a sandbox (Step 2)
-
-Cloning on the Pipeline Configurations page here typically creates a new `PipelineConfiguration`
-entity pointing at its own descriptor (e.g. your own branch of the same config repo) rather than a
-physical folder copy — so "the sandbox" is a descriptor, not a path. To get a working one:
-
-1. Clone the config's own source repo (the one behind its `descriptor`) to a local dev folder:
-   ```bash
-   git clone https://github.com/mystudio/tk-config-basic.git my-dev-config
-   cd my-dev-config
-   git checkout -b dev/my-sandbox
-   ```
-2. Point a (new or existing) sandbox `PipelineConfiguration` entity's `descriptor` at this branch,
-   e.g. `sgtk:descriptor:git?path=https://github.com/mystudio/tk-config-basic.git&version=dev/my-sandbox`
-   — ask a site admin to create/update it if you don't have permission.
-3. Edit `env/*.yml` inside `my-dev-config` and push to `dev/my-sandbox`; that's the equivalent of
-   editing the sandbox config directly. Toolkit re-resolves and re-downloads into the bundle cache
-   the next time it's used.
-
-## Cloning the app template (Step 3)
-
-No local `install/apps` to drop code into — clone into a regular dev workspace folder, and wire it
-in later via `switch_app`/a `dev` descriptor (Step 4):
-
-```bash
-git clone https://github.com/shotgunsoftware/tk-multi-starterapp.git tk-multi-myapp
-cd tk-multi-myapp
-rm -rf .git
-git init
-git remote add origin <your-studio-repo-url>   # once you have a destination to push to
-```
-
-## Release descriptor (Step 9)
-
-A git descriptor means every user's machine resolves and downloads it independently into their own
-bundle cache, so each of them needs git installed and authenticated against your repo. An App Store
-or Shotgun-uploaded descriptor avoids that per-user git dependency.
+| `shotgun?...` | Attachment on an FPTR entity — no repo, no branch/fork/PR mechanism | Download the current attachment (web UI, or `sg.download_attachment(...)`), confirm it's the latest version, and treat that unzipped folder as your one working copy — develop against it like the centralized case. Put it under git yourself for a diff/rollback safety net. Confirm you have write access on the field before assuming you can `sg.upload(...)` a new version back. |

--- a/skills/flow-ptr-app/references/distributed-config.md
+++ b/skills/flow-ptr-app/references/distributed-config.md
@@ -1,0 +1,65 @@
+# Distributed pipeline configuration
+
+Everything Steps 1-3 and 9 of SKILL.md do differently when the `PipelineConfiguration`'s
+`descriptor` field is populated and the path fields are empty.
+
+## What it looks like
+
+There is no single fixed install location. Every machine resolves the `descriptor` (typically a git
+repo + version/branch, or an `app_store` descriptor) on demand and downloads core/apps/engines into
+its own local **bundle cache** — `~/Library/Caches/Shotgun` on macOS, `%APPDATA%\Shotgun` on
+Windows, `~/.shotgun` on Linux, or wherever `SHOTGUN_BUNDLE_CACHE_PATH` points if it's set. There's
+usually still a `tank`/`tank.bat` at the root of a checked-out copy of the config's source repo, but
+it bootstraps core from the bundle cache instead of a local `install/core` — commands behave the
+same either way.
+
+## Which type is the descriptor?
+
+The `descriptor` string self-describes its type — read the scheme right after `sgtk:descriptor:`,
+before the `?`. **Read the whole row for your scheme before acting** — some carry escalation steps
+that are easy to miss if you only skim for the clone command:
+
+| Scheme | Meaning | What to do |
+|---|---|---|
+| `git?path=<url>&version=<tag>` / `git_branch?path=<url>&branch=<branch>` | Git-based; `path=` is the clone URL | `git clone <path> my-dev-config`. Auth failure → ask the repo owner/admin for read access (and write/contributor access too if you'll push back). Can clone but can't push → fork/branch to something you own, point a personal `PipelineConfiguration` at it, and PR back later — good practice even with push access, to avoid disrupting teammates on the same descriptor. No git credentials configured at all → that's an environment setup issue for the user, not a permissions one. |
+| `app_store?name=<config>&version=<version>` | Packaged release downloaded into each user's bundle cache — not a repo, not editable | Any local edit is discarded on re-resolve. Check whether the studio already forked this into an editable git-backed config (look for another `PipelineConfiguration` pointing at that fork). If none exists, moving production off an App Store descriptor is an infrastructure decision — **escalate to the pipeline lead/admin rather than doing it unilaterally.** |
+| `path?path=<location>` | Plain shared folder, not git-versioned | Treat like the centralized case (see `references/centralized-config.md`) — check read *and* write access directly on the path. |
+| `shotgun?...` | Attachment on an FPTR entity — no repo, no branch/fork/PR mechanism | Download the current attachment (web UI, or `sg.download_attachment(...)`), confirm it's the latest version, and treat that unzipped folder as your one working copy — develop against it like the centralized case (Step 3 of SKILL.md). Put it under git yourself for a diff/rollback safety net. Confirm you have write access on the field before assuming you can `sg.upload(...)` a new version back. |
+
+## Creating a sandbox (Step 2)
+
+Cloning on the Pipeline Configurations page here typically creates a new `PipelineConfiguration`
+entity pointing at its own descriptor (e.g. your own branch of the same config repo) rather than a
+physical folder copy — so "the sandbox" is a descriptor, not a path. To get a working one:
+
+1. Clone the config's own source repo (the one behind its `descriptor`) to a local dev folder:
+   ```bash
+   git clone https://github.com/mystudio/tk-config-basic.git my-dev-config
+   cd my-dev-config
+   git checkout -b dev/my-sandbox
+   ```
+2. Point a (new or existing) sandbox `PipelineConfiguration` entity's `descriptor` at this branch,
+   e.g. `sgtk:descriptor:git?path=https://github.com/mystudio/tk-config-basic.git&version=dev/my-sandbox`
+   — ask a site admin to create/update it if you don't have permission.
+3. Edit `env/*.yml` inside `my-dev-config` and push to `dev/my-sandbox`; that's the equivalent of
+   editing the sandbox config directly. Toolkit re-resolves and re-downloads into the bundle cache
+   the next time it's used.
+
+## Cloning the app template (Step 3)
+
+No local `install/apps` to drop code into — clone into a regular dev workspace folder, and wire it
+in later via `switch_app`/a `dev` descriptor (Step 4):
+
+```bash
+git clone https://github.com/shotgunsoftware/tk-multi-starterapp.git tk-multi-myapp
+cd tk-multi-myapp
+rm -rf .git
+git init
+git remote add origin <your-studio-repo-url>   # once you have a destination to push to
+```
+
+## Release descriptor (Step 9)
+
+A git descriptor means every user's machine resolves and downloads it independently into their own
+bundle cache, so each of them needs git installed and authenticated against your repo. An App Store
+or Shotgun-uploaded descriptor avoids that per-user git dependency.

--- a/skills/flow-ptr-app/references/existing-functionality.md
+++ b/skills/flow-ptr-app/references/existing-functionality.md
@@ -1,4 +1,31 @@
-# Reference apps to study
+# Find existing functionality or apps
+
+Toolkit has a customization ladder — cheaper options first:
+
+1. **Project settings** — often what looks like "custom behavior" is just a setting on an
+   existing app (`env/includes/settings/...`).
+2. **App settings** — check the target app's `info.yml` for a setting that already does this.
+3. **Hooks** — the app may already expose a hook for exactly the behavior you want to change.
+4. **An existing app, mainstream or niche** — search for one (below) before assuming none exists.
+   Fork/extend it if it's close to what you need (forking mechanics below).
+5. **A brand-new app** — only once none of the above can be reused.
+
+Best practice is to search the shotgunsoftware org by keyword — name, description, and README —
+before assuming nothing exists:
+```bash
+curl -s "https://api.github.com/search/repositories?q=<keyword>+org:shotgunsoftware+in:name,description,readme" \
+  | grep -o '"full_name": *"[^"]*"'
+```
+(Use this `curl`/api.github.com form, not `gh api`, if `gh` is configured against an internal
+GitHub Enterprise host.)
+
+Flame, Nuke, Hiero, Houdini, and Mari ship their own export/tracking apps too — check those the
+same way before scaffolding new.
+
+- A list of ready-to-use apps: https://help.autodesk.com/view/SGDEV/ENU/?guid=SGD_pc_toolkit_apps_html
+- All app/engine/framework source: https://github.com/shotgunsoftware
+
+## Reference apps to study
 
 Real Autodesk-maintained apps that each demonstrate a distinct, reusable pattern — read their
 source before designing your own app's architecture.
@@ -31,3 +58,22 @@ source before designing your own app's architecture.
   [tk-shotgun-launchfolder](https://github.com/shotgunsoftware/tk-shotgun-launchfolder),
   [tk-shotgun-launchpublish](https://github.com/shotgunsoftware/tk-shotgun-launchpublish) — minimal,
   single-action `tk-shotgun` apps.
+
+## Forking an existing app
+
+**If you decide to fork an existing app** instead of starting from the starter template, place the
+clone under `config/install/app_store` in the config, and point `app_locations.yml` at it:
+
+```yaml
+my_custom_app:
+  location:
+    type: git
+    path: git@github.com:yourstudio/tk-multi-mycustomapp.git
+    version: v1.0.0
+```
+
+When forking, best practice is to use extended version numbers (`vBASE.LOCAL`, e.g. `v0.2.12.1`) to
+indicate "based on upstream v0.2.12, plus our local patch 1" — this keeps a clear trail back to the
+original version and makes it obvious the tag isn't an upstream release.
+
+More on descriptors: https://developers.shotgridsoftware.com/tk-core/descriptor.html

--- a/skills/flow-ptr-app/references/existing-functionality.md
+++ b/skills/flow-ptr-app/references/existing-functionality.md
@@ -10,8 +10,9 @@ Toolkit has a customization ladder — cheaper options first:
    Fork/extend it if it's close to what you need (forking mechanics below).
 5. **A brand-new app** — only once none of the above can be reused.
 
-Best practice is to search the shotgunsoftware org by keyword — name, description, and README —
+Check if the functionality to develop is already exposed in one of the 1-3 options. If not, for step 4 the best practice is to search the shotgunsoftware org by keyword — name, description, and README —
 before assuming nothing exists:
+
 ```bash
 curl -s "https://api.github.com/search/repositories?q=<keyword>+org:shotgunsoftware+in:name,description,readme" \
   | grep -o '"full_name": *"[^"]*"'

--- a/skills/flow-ptr-app/references/existing-functionality.md
+++ b/skills/flow-ptr-app/references/existing-functionality.md
@@ -59,21 +59,3 @@ source before designing your own app's architecture.
   [tk-shotgun-launchpublish](https://github.com/shotgunsoftware/tk-shotgun-launchpublish) — minimal,
   single-action `tk-shotgun` apps.
 
-## Forking an existing app
-
-**If you decide to fork an existing app** instead of starting from the starter template, place the
-clone under `config/install/app_store` in the config, and point `app_locations.yml` at it:
-
-```yaml
-my_custom_app:
-  location:
-    type: git
-    path: git@github.com:yourstudio/tk-multi-mycustomapp.git
-    version: v1.0.0
-```
-
-When forking, best practice is to use extended version numbers (`vBASE.LOCAL`, e.g. `v0.2.12.1`) to
-indicate "based on upstream v0.2.12, plus our local patch 1" — this keeps a clear trail back to the
-original version and makes it obvious the tag isn't an upstream release.
-
-More on descriptors: https://developers.shotgridsoftware.com/tk-core/descriptor.html

--- a/skills/flow-ptr-app/references/implement-app.md
+++ b/skills/flow-ptr-app/references/implement-app.md
@@ -1,0 +1,51 @@
+# Implement a Flow PTR app
+
+- `app.py`: `Application` subclass, registers menu command(s) via `self.engine.register_command(...)`.
+- `python/app/dialog.py`: dialog construction and callbacks.
+- Support **both** UI and no-UI execution paths, since not every engine/context has Qt available:
+  - **With UI**: full Qt window via `self.engine.show_dialog(...)` (PySide2/PySide6 or PyQt).
+  - **Without UI**: a console-only code path (check `self.engine.has_ui`) so the app still works
+    headlessly, e.g. under `tk-shell` or a batch/farm context.
+  - Qt bindings (PySide/PyQt) must be available in whichever Python environment runs the DCP/engine
+    — install PySide2/PySide6 (or PyQt) into that environment if it's missing.
+- As soon as the config has one or more `dev`-descriptor apps in it, Toolkit adds a **Reload and
+  Restart** entry to the PTR menu — use it to pick up code and config changes without restarting
+  the host application. It reloads the config and code and restarts the engine, but any app UI
+  already open on screen does **not** auto-update — close and re-launch it from the menu after
+  reloading to see your changes.
+- App logic will mainly talk to PTR through the **Python API** (`shotgun_api3`, already available
+  via `sgtk`/the engine). It may also need the **REST API** for cases outside a Python/DCC context
+  (e.g. external services, non-Python integrations): https://developers.shotgridsoftware.com/rest-api/
+
+## Web menu action (`tk-shotgun` engine)
+
+Apps launched from a right-click menu in the FPTR **web** UI (not from inside a DCC) run under the
+`tk-shotgun` engine, which behaves differently from DCC engines like `tk-maya`:
+
+1. Clicking the menu action in the browser sends a request to FPTR Desktop.
+2. Desktop spawns a separate local Python process and bootstraps the `tk-shotgun` engine in it.
+3. Your app code runs in that process — same idea as `python script.py` from the command line,
+   but with the Toolkit framework loaded.
+4. If UI is needed, a Qt app starts there (same with-UI/without-UI detection as above).
+5. All output is captured and sent back to the web interface **only after the process
+   completes** — it is not streamed live.
+
+Implications: this requires FPTR Desktop to be installed and running, plus network connectivity
+for the API calls. Logging goes to the standard Toolkit log files, not the browser console — set
+`debug_logging: true` (see [Adjust the app manifest, `info.yml`](app-manifest.md)) while
+iterating. Don't confuse `tk-shotgun` with `tk-desktop` (the engine that runs *inside* the Desktop
+launcher itself) — they're different engines.
+
+## Triggering custom events
+
+If other systems (the studio's Event Framework daemon, webhooks) should react to something your
+app does, create an `EventLogEntry` yourself via the Python API, e.g.
+`sg.create("EventLogEntry", data)`, using the same naming convention FPTR uses internally:
+`ApplicationName_EntityType_Action` (e.g. `tkMultiEventApp_event_new`).
+
+## Python API best practices
+
+Before writing any non-trivial `sg.find`/`sg.create` calls, read
+[python-api-best-practices.md](python-api-best-practices.md) — performance, API-key/script
+hygiene, and design guidance that's cheap to follow now and expensive to retrofit later. Skip only
+for trivial, one-off calls.

--- a/skills/flow-ptr-app/references/install-app.md
+++ b/skills/flow-ptr-app/references/install-app.md
@@ -1,0 +1,61 @@
+# Install an app into the target configuration
+
+Pick the environment (e.g. `shot_step` for Shots, `asset_step` for Assets, or `project` if the app
+only needs project-level context) and the engine you're targeting (`tk-maya`, `tk-nuke`,
+`tk-desktop`, `tk-shell`, ...). Starting with the `tk-shell` engine in the `project` environment is
+often the fastest loop for early logic-only development (no DCC startup required, and you can run
+it straight from the command line or your IDE if you have a centralized config) — you can wire up
+DCC-specific UI/menus afterwards.
+
+**Fastest path — a `dev` location descriptor directly (no git tag needed yet):** a brand-new app
+has no git tag to `install_app` from anyway, so for early development just hand-edit the
+environment YAML and point the app straight at your local checkout:
+
+```yaml
+tk-multi-myapp:
+  location:
+    type: dev
+    path: /path/to/source_code/tk-multi-myapp
+```
+
+This goes wherever the app is wired into an engine's settings (e.g.
+`env/includes/settings/tk-shell.yml`'s `apps:` block for the environment you picked). Toolkit loads
+the code directly from that path, so every edit is picked up on the next reload — no reinstall
+step, and no git repo is needed yet.
+
+`type: dev` is about the development workflow (it's what turns on the "Reload and Restart" menu
+command), not about *where* the code physically sits — `path:` just points at wherever the app's
+source was cloned to. So it's still `type: dev` whether that path is
+`<configuration_folder>/install/apps/<name>` or an external workspace folder; the type only changes
+once the app stops being actively developed and gets a real release descriptor (`git`/`app_store`/
+...) — see [Release and push to production](release.md).
+
+**Alternative — `install_app` + `switch_app`:** useful once the app already has at least one git
+tag (e.g. it started life as an app-store/git app and you're now developing a new feature for it).
+From a shell, `cd` into the sandbox and use its `tank` command:
+
+```bash
+cd /your/development/sandbox
+./tank install_app shot_step tk-maya user@remotehost:/path_to/tk-multi-mynewapp.git
+```
+
+This installs the latest git tag. Launch the DCC from the sandbox against a Shot/Asset task to
+confirm the app loads. Then switch Toolkit to track your local checkout instead of the git tag, so
+code edits are picked up immediately — this produces the same `type: dev` location entry as the
+fastest-path option above, just generated for you rather than hand-written:
+
+```bash
+./tank switch_app shot_step tk-maya tk-multi-mynewapp /Users/you/dev/tk-multi-mynewapp
+```
+
+Either way, these are the files under the sandbox's config that end up changed — useful to know
+when reviewing the diff before `push_configuration`:
+- `env/includes/app_locations.yml` — where Toolkit finds the app's code (git repo, local path, etc.)
+- `env/includes/settings/<my_custom_app>.yml` — the app's own settings for this project
+- `env/includes/settings/tk-<engine>.yml` — wires the app into an engine + pipeline step
+  (asset/shot/sequence/...); make sure the app's settings file is included at the top of this file
+
+> **Engine version:** when the environment config pins an engine (e.g. `tk-maya`), best practice
+> is to use the latest available engine version for that environment rather than an old pinned
+> one — you get current bug fixes and it avoids chasing issues in the engine that have already
+> been fixed upstream.

--- a/skills/flow-ptr-app/references/locating-config.md
+++ b/skills/flow-ptr-app/references/locating-config.md
@@ -1,0 +1,38 @@
+# Locating a project configuration
+
+Find the `PipelineConfiguration` you'll actually be developing against, and figure out how it's
+set up. This determines where files live, whether there's a local `tank` command to run, and
+where the app's code should be cloned.
+
+Check the project's **Pipeline Configurations** page in Flow Production Tracking, or query it via
+the API:
+
+```python
+sg.find_one(
+    "PipelineConfiguration",
+    [["project", "is", {"type": "Project", "id": PROJECT_ID}], ["code", "is", "Primary"]],
+    ["mac_path", "windows_path", "linux_path", "descriptor"],
+)
+```
+
+**Planning boundary:** this query (and reading the descriptor scheme below) is read-only and safe
+to run during a plan pass — it doesn't touch the filesystem or any repo. Almost everything else in
+this guide branches on what it returns (sandbox strategy, install method, and whether this lookup
+itself ends in "blocked, escalate" for some descriptor types), so best practice is to run this
+lookup first and draft the rest of the plan *after* it returns, rather than planning the whole
+thing upfront. Everything from here on — cloning, write-access probes, `tank` commands — is
+execution, not planning.
+
+- **Populated `mac_path`/`windows_path`/`linux_path`, no `descriptor`** → **centralized (classic)**
+  configuration.
+- **Populated `descriptor`, empty path fields** → **distributed** configuration.
+
+**Centralized (classic):** the whole config lives at one fixed path shared by every machine. Read
+[centralized-config.md](centralized-config.md) before continuing — it covers the access checks you
+must run before touching that path, plus how sandboxing, cloning, and the final release descriptor
+differ for this config type.
+
+**Distributed:** there's no single fixed install location — every machine resolves the `descriptor`
+on demand into its own local bundle cache. Read [distributed-config.md](distributed-config.md)
+before continuing — read the whole file, not just the descriptor-type table: some descriptor types
+(App Store, FPTR-attachment) carry escalation steps that are easy to miss if skipped.

--- a/skills/flow-ptr-app/references/python-api-best-practices.md
+++ b/skills/flow-ptr-app/references/python-api-best-practices.md
@@ -1,0 +1,36 @@
+# Python API best practices (shotgun_api3 / sgtk)
+
+Guide: https://help.autodesk.com/view/SGDEV/ENU/?guid=SGD_py_python_api_best_practices_html
+
+**Performance**
+- Don't request fields you don't need in `sg.find(...)` — extra fields add overhead.
+- Make filters as specific as possible; filter in the API query rather than fetching everything
+  and parsing/filtering the results in Python.
+- Exact-match filters (`is`) perform better than partial-match filters (`contains`).
+- For linked entities, requesting the bare `entity` field already gives you type/id/name for
+  free. Only use dot notation (`entity.Asset.code`) when you need a field beyond those three, since
+  it's slower.
+
+**Control and debugging**
+- Use a separate API key per script/tool — invaluable for debugging.
+- Every script should have an owner/maintainer kept current on the Scripts page (Admin menu).
+- Consider a read-only permission group for API users that only need read access, to limit
+  exposure to accidental writes.
+- Track which keys are actually in use so old/retired scripts' keys can be removed (some studios
+  log this in their API wrapper).
+- Don't assume you can predict a field's API name from its UI display name (they can differ and
+  the display name can change) — look it up under Admin > Fields, or via `schema_read()`,
+  `schema_field_read()`, `schema_entity_read()`.
+
+**Design**
+- For larger studios, consider an API isolation layer/wrapper so tools are shielded from API
+  changes and access/debugging/auditing can be centralized without touching the API itself.
+- Use the latest API version for its bug fixes and performance improvements — same rationale as
+  using the latest engine version for a pinned engine.
+- Be aware of where the script runs: something on a render farm calling PTR thousands of times a
+  minute can hurt site performance — put a read-only caching layer in front of it.
+- You can turn off event generation for scripts that run very often and whose events you won't
+  need to track later — recommended for high-frequency scripts, since otherwise the event log can
+  grow very large. Conversely, this is a togglable setting on the script's API key ("Generate
+  Events") — if your app needs to create events (see "Triggering custom events" in SKILL.md) and
+  nothing is showing up, check that this is enabled for the key it authenticates with.

--- a/skills/flow-ptr-app/references/reference-apps.md
+++ b/skills/flow-ptr-app/references/reference-apps.md
@@ -1,0 +1,33 @@
+# Reference apps to study
+
+Real Autodesk-maintained apps that each demonstrate a distinct, reusable pattern — read their
+source before designing your own app's architecture.
+
+**Architectural patterns (DCC-side)**
+- [tk-multi-publish2](https://github.com/shotgunsoftware/tk-multi-publish2) — collector +
+  pluggable publish-plugin hooks (`accept()` → `validate()` → `publish()` → `finalize()`). Use
+  this as the reference if your app needs a "process N items through configurable tasks" workflow.
+- [tk-multi-workfiles2](https://github.com/shotgunsoftware/tk-multi-workfiles2) — a moderately
+  complex app sliced into 9 independent hooks rather than one monolith.
+- [tk-multi-loader2](https://github.com/shotgunsoftware/tk-multi-loader2) — dispatches different
+  logic per published-file-type via an `actions_hook`.
+- [tk-multi-breakdown2](https://github.com/shotgunsoftware/tk-multi-breakdown2) — compares scene
+  state against PTR's published data and flags what's out of date.
+
+**Simple, minimal apps**
+- [tk-multi-about](https://github.com/shotgunsoftware/tk-multi-about) — read-only, no side
+  effects; closest thing to a "hello world" Toolkit app.
+- [tk-multi-snapshot](https://github.com/shotgunsoftware/tk-multi-snapshot) — single-purpose local
+  utility, no PTR data beyond the local file, no hooks needed.
+- [tk-multi-launchapp](https://github.com/shotgunsoftware/tk-multi-launchapp) — its entire
+  customization surface is one hook (`before_app_launch`); good "one hook is enough" reference.
+
+**Web menu-action apps (`tk-shotgun` engine)**
+- [tk-shotgun-setupproject](https://github.com/shotgunsoftware/tk-shotgun-setupproject) — a full
+  project-setup wizard triggered from the web UI.
+- [tk-shotgun-launchvredreview](https://github.com/shotgunsoftware/tk-shotgun-launchvredreview) —
+  a web action that launches an external tool (VRED) for review.
+- [tk-shotgun-folders](https://github.com/shotgunsoftware/tk-shotgun-folders),
+  [tk-shotgun-launchfolder](https://github.com/shotgunsoftware/tk-shotgun-launchfolder),
+  [tk-shotgun-launchpublish](https://github.com/shotgunsoftware/tk-shotgun-launchpublish) — minimal,
+  single-action `tk-shotgun` apps.

--- a/skills/flow-ptr-app/references/release.md
+++ b/skills/flow-ptr-app/references/release.md
@@ -23,9 +23,21 @@ Other descriptor types are available for the final `location` entry besides a gi
 GitHub releases, or a Shotgun-uploaded attachment — pick whichever matches how the studio
 distributes Toolkit apps.
 
-Descriptor choice for this final release step also differs by config type — see the "Release
-descriptor" note in whichever reference file matches the project's config type
-([centralized-config.md](centralized-config.md) / [distributed-config.md](distributed-config.md)).
+Descriptor choice for this final release step also differs by the project's config type (see
+[locating-config.md](locating-config.md) if you haven't determined that yet):
+
+## Centralized config
+
+A git descriptor works well here — one admin runs the update and the resolved code is cached once,
+in a location every user already shares. See [centralized-config.md](centralized-config.md) for
+more on this layout.
+
+## Distributed config
+
+A git descriptor means every user's machine resolves and downloads it independently into their own
+bundle cache, so each of them needs git installed and authenticated against your repo. An App Store
+or Shotgun-uploaded descriptor avoids that per-user git dependency. See
+[distributed-config.md](distributed-config.md) for more on this layout.
 
 **Later, when you ship a new version:** bump the version manually in `app_locations.yml` (and
 `core_api.yml` if it's a core update), or use the Desktop app's Project menu → "Check for

--- a/skills/flow-ptr-app/references/release.md
+++ b/skills/flow-ptr-app/references/release.md
@@ -1,0 +1,33 @@
+# Release and push to production
+
+An app must be versioned to be installed via a git/App Store/GitHub descriptor at all — Toolkit
+resolves `version:` against git tags, so every release needs one. Use semantic versioning
+(`vMAJOR.MINOR.PATCH`, e.g. start at `v0.1.0` during early development, `v1.0.0` for the first
+production-ready release) and bump it for every change you want the config to be able to pin to.
+
+Tag a version in git (e.g. `v1.0.0`), then switch the sandbox back from dev mode to the tagged
+git descriptor:
+
+```bash
+./tank switch_app shot_step tk-maya tk-multi-mynewapp user@remotehost:/path_to/tk-multi-mynewapp.git
+```
+
+Toolkit will pick up the highest-numbered tag. Finally, push the sandbox's config changes to the
+project's primary production configuration:
+
+```bash
+./tank push_configuration
+```
+
+Other descriptor types are available for the final `location` entry besides a git tag — App Store,
+GitHub releases, or a Shotgun-uploaded attachment — pick whichever matches how the studio
+distributes Toolkit apps.
+
+Descriptor choice for this final release step also differs by config type — see the "Release
+descriptor" note in whichever reference file matches the project's config type
+([centralized-config.md](centralized-config.md) / [distributed-config.md](distributed-config.md)).
+
+**Later, when you ship a new version:** bump the version manually in `app_locations.yml` (and
+`core_api.yml` if it's a core update), or use the Desktop app's Project menu → "Check for
+configs/core updates" to upgrade automatically, or use `tank` from the project's config, or the
+update API — whichever fits the studio's workflow.

--- a/skills/flow-ptr-app/references/sandbox-dev-configuration.md
+++ b/skills/flow-ptr-app/references/sandbox-dev-configuration.md
@@ -9,8 +9,32 @@ First check whether a dev sandbox already exists for this project — look for o
 cloned/flagged for dev use on the Pipeline Configurations page, or ask the user directly. If one
 exists, target it instead of production.
 
-If one doesn't exist yet, create it by following the "Creating a sandbox" section of whichever
-reference file matches the config type —
-[centralized-config.md](centralized-config.md) or
-[distributed-config.md](distributed-config.md). Either way, once you have a
-target configuration you also know where the app's own code should be cloned to next.
+If one doesn't exist yet, create it based on the project's config type (see
+[locating-config.md](locating-config.md) if you haven't determined that yet):
+
+## Centralized config
+
+Right-click the primary config on the Pipeline Configurations page and **Clone** it. This produces
+a second `PipelineConfiguration` entity with its own path fields and an on-disk copy with the same
+`config/`/`install/`/`tank` structure as the original (see
+[centralized-config.md](centralized-config.md)) — that copy is your sandbox.
+
+## Distributed config
+
+Cloning on the Pipeline Configurations page here typically creates a new `PipelineConfiguration`
+entity pointing at its own descriptor (e.g. your own branch of the same config repo) rather than a
+physical folder copy — so "the sandbox" is a descriptor, not a path (see
+[distributed-config.md](distributed-config.md)). To get a working one:
+
+1. Clone the config's own source repo (the one behind its `descriptor`) to a local dev folder:
+   ```bash
+   git clone https://github.com/mystudio/tk-config-basic.git my-dev-config
+   cd my-dev-config
+   git checkout -b dev/my-sandbox
+   ```
+2. Point a (new or existing) sandbox `PipelineConfiguration` entity's `descriptor` at this branch,
+   e.g. `sgtk:descriptor:git?path=https://github.com/mystudio/tk-config-basic.git&version=dev/my-sandbox`
+   — ask a site admin to create/update it if you don't have permission.
+3. Edit `env/*.yml` inside `my-dev-config` and push to `dev/my-sandbox`; that's the equivalent of
+   editing the sandbox config directly. Toolkit re-resolves and re-downloads into the bundle cache
+   the next time it's used.

--- a/skills/flow-ptr-app/references/sandbox-dev-configuration.md
+++ b/skills/flow-ptr-app/references/sandbox-dev-configuration.md
@@ -1,0 +1,16 @@
+# Find or create a sandbox/dev configuration (strongly advised, not mandatory)
+
+You *can* develop directly against the project's production configuration instead of a sandbox —
+Toolkit doesn't technically stop you. It's just a bad idea: a half-finished app can break real
+menus/commands for everyone else on the project, and any test data/events you generate land in
+production. Best practice is to use a sandbox unless you have a specific reason not to.
+
+First check whether a dev sandbox already exists for this project — look for one already
+cloned/flagged for dev use on the Pipeline Configurations page, or ask the user directly. If one
+exists, target it instead of production.
+
+If one doesn't exist yet, create it by following the "Creating a sandbox" section of whichever
+reference file matches the config type —
+[centralized-config.md](centralized-config.md) or
+[distributed-config.md](distributed-config.md). Either way, once you have a
+target configuration you also know where the app's own code should be cloned to next.

--- a/skills/flow-ptr-app/references/test-app.md
+++ b/skills/flow-ptr-app/references/test-app.md
@@ -1,0 +1,16 @@
+# Test an app
+
+- Iterate using Toolkit's **Reload and Restart** menu item to pick up code and config changes
+  without restarting the host application (see [Implement a Flow PTR app](implement-app.md) for
+  what enables it and its limits).
+- Ask whether to verify headless in `tk-shell` first before testing in the final DCC/engine, or go
+  straight to the final target — `tk-shell` first gives a faster logic-only loop (no DCC startup)
+  and catches non-UI bugs early, but ultimately the dialog/UI still needs to be confirmed working
+  in the real target engine (`tk-desktop` or the DCC itself) before calling it tested.
+- To bring in another tester without giving them production access, add them to the
+  **User Restrictions** field on the sandbox's `PipelineConfiguration` entity in PTR, and make sure
+  they have read access to your app's repo/checkout.
+- The Python API is useful for writing quick test scripts or exercising app logic against real
+  PTR data outside the DCC:
+  - https://developers.shotgridsoftware.com/python-api/
+  - https://help.autodesk.com/view/SGDEV/ENU/?guid=SGD_py_python_api_overview_html


### PR DESCRIPTION
## Summary
- Add `flow-ptr-app`, a spec-driven skill for building Flow Production Tracking (FPTR) / ShotGrid Toolkit apps — 9-phase lifecycle (intent capture → spec → plan → scaffold → implement → verify → release → maintenance) backed by 13 reference guides.
- Update the top-level README: broaden the intro to cover Flow/industry-cloud skills alongside APS, and list `flow-ptr-app` in the Available Skills table with its install command.